### PR TITLE
feat: Phase 3 — Conversational Memory

### DIFF
--- a/alembic/versions/009_add_conversations.py
+++ b/alembic/versions/009_add_conversations.py
@@ -1,0 +1,65 @@
+"""Add conversations and messages tables.
+
+Revision ID: 009
+Revises: 008
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("title", sa.String(500), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("last_active", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
+    op.create_index("ix_conversations_project_id", "conversations", ["project_id"])
+    op.create_index("ix_conversations_last_active", "conversations", ["last_active"])
+
+    op.create_table(
+        "messages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("metadata", postgresql.JSONB, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "role IN ('user', 'assistant', 'system')",
+            name="ck_messages_role",
+        ),
+    )
+    op.create_index("ix_messages_conversation_id", "messages", ["conversation_id"])
+    op.create_index("ix_messages_created_at", "messages", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("messages")
+    op.drop_table("conversations")

--- a/docs/superpowers/plans/2026-04-02-universal-memory-layer-phase4-semantic-metadata.md
+++ b/docs/superpowers/plans/2026-04-02-universal-memory-layer-phase4-semantic-metadata.md
@@ -1,0 +1,2618 @@
+# Universal Memory Layer — Phase 4: Semantic Metadata Layer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Finch-inspired glossary service that stores curated domain terminology (canonical terms + aliases) and resolves aliases in user queries before search, improving retrieval recall.
+
+**Architecture:** A `GlossaryService` wraps PostgreSQL (durable storage) and Elasticsearch (kNN semantic search + keyword matching on aliases). When a user queries "What's the GBs target?", the alias resolver expands "GBs" to "Gross Bookings" before the query hits search. Three access layers: REST API (`/api/glossary`), MCP tools (`pam_glossary_add`, `pam_glossary_search`, `pam_glossary_resolve`), and the Python service directly. Context assembly gains a glossary section for relevant terms.
+
+**Tech Stack:** SQLAlchemy 2.x (async, PG ARRAY type for aliases), Elasticsearch 8.x (dense_vector kNN + keyword matching), OpenAI embeddings (text-embedding-3-large, 1536d), Alembic migration, FastAPI routes, FastMCP tools, pytest
+
+---
+
+## File Structure
+
+### New Files
+
+```
+src/pam/glossary/
+  __init__.py              # Re-exports GlossaryService, GlossaryStore
+  store.py                 # GlossaryStore — ES index ops (index, search, delete)
+  service.py               # GlossaryService — CRUD, semantic search, dedup
+  resolver.py              # AliasResolver — fuzzy alias matching + query expansion
+
+src/pam/api/routes/glossary.py  # REST endpoints: POST, GET, PUT, DELETE, search, resolve, list
+
+alembic/versions/010_add_glossary_terms.py  # Migration for glossary_terms table
+
+tests/glossary/
+  __init__.py
+  conftest.py              # Mock fixtures for GlossaryService, GlossaryStore
+  test_store.py            # GlossaryStore unit tests
+  test_service.py          # GlossaryService unit tests
+  test_resolver.py         # AliasResolver unit tests
+```
+
+### Modified Files
+
+```
+src/pam/common/models.py        # Add GlossaryTerm ORM model + Pydantic schemas
+src/pam/common/config.py        # Add glossary_index, glossary_dedup_threshold settings
+src/pam/mcp/server.py           # Add _register_glossary_tools + pam://glossary resource
+src/pam/mcp/services.py         # Add glossary_service field to PamServices
+src/pam/api/main.py             # Initialize GlossaryService + register glossary routes
+src/pam/agent/context_assembly.py  # Add glossary_tokens budget + glossary section
+src/pam/agent/agent.py          # Integrate alias resolution before search
+```
+
+---
+
+## Task 1: GlossaryTerm ORM Model + Pydantic Schemas
+
+**Files:**
+- Modify: `src/pam/common/models.py`
+- Create: `tests/glossary/__init__.py`
+- Test: `tests/glossary/test_service.py` (first test only)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/glossary/__init__.py` (empty file).
+
+Create `tests/glossary/test_service.py`:
+
+```python
+"""Tests for GlossaryTerm model and schemas."""
+
+from pam.common.models import GlossaryTerm
+
+
+def test_glossary_term_model_has_required_fields():
+    """GlossaryTerm ORM model has all expected columns."""
+    columns = {c.name for c in GlossaryTerm.__table__.columns}
+    expected = {
+        "id", "project_id", "canonical", "aliases", "definition",
+        "category", "metadata", "created_at", "updated_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_glossary_term_model_has_required_fields -v`
+Expected: FAIL with `ImportError: cannot import name 'GlossaryTerm'`
+
+- [ ] **Step 3: Add GlossaryTerm ORM model to models.py**
+
+Add the following import at the top of `src/pam/common/models.py` (add `ARRAY` to the postgresql imports):
+
+```python
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+```
+
+Add this after the `Message` class and before the Pydantic schemas section:
+
+```python
+class GlossaryTerm(Base):
+    __tablename__ = "glossary_terms"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), index=True
+    )
+    canonical: Mapped[str] = mapped_column(String(300), nullable=False)
+    aliases: Mapped[list[str]] = mapped_column(ARRAY(Text), server_default=text("'{}'::text[]"))
+    definition: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(String(50), nullable=False)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "category IN ('metric', 'team', 'product', 'acronym', 'concept', 'other')",
+            name="ck_glossary_terms_category",
+        ),
+        UniqueConstraint("project_id", "canonical", name="uq_glossary_terms_project_canonical"),
+        {"comment": "Curated domain terminology with aliases for query expansion"},
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_glossary_term_model_has_required_fields -v`
+Expected: PASS
+
+- [ ] **Step 5: Add Pydantic schemas for Glossary**
+
+Add the following to `src/pam/common/models.py` after the Conversation schemas section:
+
+```python
+# -- Glossary Schemas --
+
+
+class GlossaryTermCreate(BaseModel):
+    canonical: str = Field(min_length=1, max_length=300)
+    aliases: list[str] = Field(default_factory=list)
+    definition: str = Field(min_length=1, max_length=5_000)
+    category: Literal["metric", "team", "product", "acronym", "concept", "other"] = "concept"
+    metadata: dict = Field(default_factory=dict)
+    project_id: uuid.UUID | None = None
+
+
+class GlossaryTermResponse(BaseModel):
+    id: uuid.UUID
+    project_id: uuid.UUID | None = None
+    canonical: str
+    aliases: list[str] = Field(default_factory=list)
+    definition: str
+    category: str
+    metadata: dict = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class GlossaryTermUpdate(BaseModel):
+    canonical: str | None = Field(default=None, min_length=1, max_length=300)
+    aliases: list[str] | None = None
+    definition: str | None = Field(default=None, min_length=1, max_length=5_000)
+    category: Literal["metric", "team", "product", "acronym", "concept", "other"] | None = None
+    metadata: dict | None = None
+
+
+class GlossarySearchResult(BaseModel):
+    term: GlossaryTermResponse
+    score: float
+
+
+class GlossaryResolveResult(BaseModel):
+    original_query: str
+    expanded_query: str
+    resolved_terms: list[dict] = Field(default_factory=list)
+```
+
+- [ ] **Step 6: Write schema tests**
+
+Add to `tests/glossary/test_service.py`:
+
+```python
+import pytest
+
+from pam.common.models import (
+    GlossaryTermCreate,
+    GlossaryTermResponse,
+    GlossaryTermUpdate,
+)
+
+
+def test_glossary_term_create_defaults():
+    """GlossaryTermCreate has correct defaults."""
+    tc = GlossaryTermCreate(canonical="Gross Bookings", definition="Total fare amount")
+    assert tc.category == "concept"
+    assert tc.aliases == []
+    assert tc.metadata == {}
+    assert tc.project_id is None
+
+
+def test_glossary_term_create_with_aliases():
+    """GlossaryTermCreate accepts aliases."""
+    tc = GlossaryTermCreate(
+        canonical="Gross Bookings",
+        aliases=["GBs", "gross books"],
+        definition="Total fare amount before deductions",
+        category="metric",
+    )
+    assert tc.aliases == ["GBs", "gross books"]
+    assert tc.category == "metric"
+
+
+def test_glossary_term_create_rejects_empty_canonical():
+    """GlossaryTermCreate rejects empty canonical."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GlossaryTermCreate(canonical="", definition="Something")
+
+
+def test_glossary_term_create_rejects_invalid_category():
+    """GlossaryTermCreate rejects invalid category."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GlossaryTermCreate(canonical="Test", definition="Def", category="invalid")
+```
+
+- [ ] **Step 7: Run all glossary tests**
+
+Run: `python -m pytest tests/glossary/test_service.py -v`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tests/glossary/__init__.py tests/glossary/test_service.py src/pam/common/models.py
+git commit -m "feat(glossary): add GlossaryTerm ORM model and Pydantic schemas"
+```
+
+---
+
+## Task 2: Alembic Migration
+
+**Files:**
+- Create: `alembic/versions/010_add_glossary_terms.py`
+
+- [ ] **Step 1: Write the migration**
+
+Create `alembic/versions/010_add_glossary_terms.py`:
+
+```python
+"""Add glossary_terms table for semantic metadata layer.
+
+Revision ID: 010
+Revises: 009
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "glossary_terms",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("canonical", sa.String(300), nullable=False),
+        sa.Column("aliases", ARRAY(sa.Text), server_default=sa.text("'{}'::text[]")),
+        sa.Column("definition", sa.Text, nullable=False),
+        sa.Column("category", sa.String(50), nullable=False),
+        sa.Column("metadata", JSONB, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "category IN ('metric', 'team', 'product', 'acronym', 'concept', 'other')",
+            name="ck_glossary_terms_category",
+        ),
+        sa.UniqueConstraint("project_id", "canonical", name="uq_glossary_terms_project_canonical"),
+        comment="Curated domain terminology with aliases for query expansion",
+    )
+    op.create_index("ix_glossary_terms_project_id", "glossary_terms", ["project_id"])
+    op.create_index("ix_glossary_terms_category", "glossary_terms", ["category"])
+    op.create_index("ix_glossary_terms_canonical", "glossary_terms", ["canonical"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_glossary_terms_canonical", table_name="glossary_terms")
+    op.drop_index("ix_glossary_terms_category", table_name="glossary_terms")
+    op.drop_index("ix_glossary_terms_project_id", table_name="glossary_terms")
+    op.drop_table("glossary_terms")
+```
+
+- [ ] **Step 2: Verify migration syntax**
+
+Run: `python -m py_compile alembic/versions/010_add_glossary_terms.py`
+Expected: No output (clean compile)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add alembic/versions/010_add_glossary_terms.py
+git commit -m "feat(glossary): add Alembic migration for glossary_terms table"
+```
+
+---
+
+## Task 3: Configuration Settings
+
+**Files:**
+- Modify: `src/pam/common/config.py`
+- Test: `tests/glossary/test_service.py` (add config test)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/glossary/test_service.py`:
+
+```python
+def test_glossary_config_settings_exist():
+    """Config has glossary-related settings."""
+    from pam.common.config import Settings
+
+    fields = Settings.model_fields
+    assert "glossary_index" in fields
+    assert "glossary_dedup_threshold" in fields
+    assert "glossary_context_budget" in fields
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_glossary_config_settings_exist -v`
+Expected: FAIL with `AssertionError`
+
+- [ ] **Step 3: Add glossary settings to config.py**
+
+Add the following to `src/pam/common/config.py` in the `Settings` class, after the `# Memory Service` section:
+
+```python
+    # Glossary / Semantic Metadata
+    glossary_index: str = "pam_glossary"  # ES index for glossary term embeddings
+    glossary_dedup_threshold: float = 0.92  # Cosine similarity threshold for term dedup
+    glossary_context_budget: int = 1000  # Token budget for glossary terms in context assembly
+```
+
+Also update the `_check_constraints` validator to validate `glossary_dedup_threshold`. Add after the `memory_dedup_threshold` check:
+
+```python
+        if not 0.0 <= self.glossary_dedup_threshold <= 1.0:
+            raise ValueError(f"glossary_dedup_threshold must be 0.0-1.0, got {self.glossary_dedup_threshold}")
+```
+
+And update the total_budget calculation to include glossary:
+
+```python
+        total_budget = (
+            self.context_entity_budget
+            + self.context_relationship_budget
+            + self.context_memory_budget
+            + self.conversation_context_max_tokens
+            + self.glossary_context_budget
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_glossary_config_settings_exist -v`
+Expected: PASS
+
+- [ ] **Step 5: Update context_max_tokens default to accommodate glossary budget**
+
+In `config.py`, increase `context_max_tokens` default from 16000 to 17000 to accommodate the new glossary budget:
+
+```python
+    context_max_tokens: int = 17000
+```
+
+- [ ] **Step 6: Run existing config tests to ensure no regressions**
+
+Run: `python -m pytest tests/ -k "config" -v --no-header 2>&1 | head -30`
+Expected: All existing config tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pam/common/config.py tests/glossary/test_service.py
+git commit -m "feat(glossary): add glossary config settings and context budget"
+```
+
+---
+
+## Task 4: GlossaryStore (Elasticsearch)
+
+**Files:**
+- Create: `src/pam/glossary/__init__.py`
+- Create: `src/pam/glossary/store.py`
+- Create: `tests/glossary/conftest.py`
+- Create: `tests/glossary/test_store.py`
+
+- [ ] **Step 1: Write the failing test for index mapping**
+
+Create `tests/glossary/conftest.py`:
+
+```python
+"""Shared fixtures for glossary tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pam.glossary.store import GlossaryStore
+
+
+@pytest.fixture()
+def mock_es_client() -> AsyncMock:
+    """Create a mock Elasticsearch client."""
+    client = AsyncMock()
+    client.indices = AsyncMock()
+    client.indices.exists = AsyncMock(return_value=False)
+    client.indices.create = AsyncMock()
+    client.options = MagicMock(return_value=AsyncMock())
+    return client
+
+
+@pytest.fixture()
+def glossary_store(mock_es_client: AsyncMock) -> GlossaryStore:
+    """Create a GlossaryStore with mocked ES client."""
+    return GlossaryStore(
+        client=mock_es_client,
+        index_name="test_glossary",
+        embedding_dims=1536,
+    )
+
+
+@pytest.fixture()
+def mock_embedder() -> AsyncMock:
+    """Create a mock embedder."""
+    embedder = AsyncMock()
+    embedder.embed_texts = AsyncMock(return_value=[[0.1] * 1536])
+    return embedder
+
+
+@pytest.fixture()
+def mock_store() -> AsyncMock:
+    """Create a mock GlossaryStore."""
+    store = AsyncMock(spec=GlossaryStore)
+    store.find_duplicates = AsyncMock(return_value=[])
+    store.index_term = AsyncMock()
+    store.search = AsyncMock(return_value=[])
+    store.search_by_alias = AsyncMock(return_value=[])
+    store.delete = AsyncMock()
+    return store
+
+
+@pytest.fixture()
+def mock_session_factory() -> MagicMock:
+    """Create a mock async session factory."""
+    factory = MagicMock()
+    session = AsyncMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory
+```
+
+Create `tests/glossary/test_store.py`:
+
+```python
+"""Tests for GlossaryStore ES operations."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from pam.glossary.store import GlossaryStore, get_glossary_index_mapping
+
+
+def test_glossary_index_mapping_structure():
+    """Index mapping has correct fields and types."""
+    mapping = get_glossary_index_mapping(1536)
+    props = mapping["mappings"]["properties"]
+
+    assert props["embedding"]["type"] == "dense_vector"
+    assert props["embedding"]["dims"] == 1536
+    assert props["embedding"]["similarity"] == "cosine"
+    assert props["canonical"]["type"] == "keyword"
+    assert props["aliases"]["type"] == "keyword"
+    assert props["definition"]["type"] == "text"
+    assert props["category"]["type"] == "keyword"
+    assert props["project_id"]["type"] == "keyword"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/glossary/test_store.py::test_glossary_index_mapping_structure -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pam.glossary'`
+
+- [ ] **Step 3: Create the GlossaryStore**
+
+Create `src/pam/glossary/__init__.py`:
+
+```python
+"""Glossary / Semantic Metadata Layer -- curated domain terminology."""
+```
+
+Create `src/pam/glossary/store.py`:
+
+```python
+"""Elasticsearch store for glossary term embeddings and search."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+import structlog
+
+if TYPE_CHECKING:
+    from elasticsearch import AsyncElasticsearch
+
+logger = structlog.get_logger()
+
+
+def get_glossary_index_mapping(embedding_dims: int) -> dict:
+    """Build the ES index mapping for glossary terms."""
+    return {
+        "mappings": {
+            "properties": {
+                "canonical": {"type": "keyword", "normalizer": "lowercase"},
+                "canonical_text": {"type": "text", "analyzer": "standard"},
+                "aliases": {"type": "keyword", "normalizer": "lowercase"},
+                "aliases_text": {"type": "text", "analyzer": "standard"},
+                "definition": {"type": "text", "analyzer": "standard"},
+                "category": {"type": "keyword"},
+                "project_id": {"type": "keyword"},
+                "embedding": {
+                    "type": "dense_vector",
+                    "dims": embedding_dims,
+                    "index": True,
+                    "similarity": "cosine",
+                },
+                "created_at": {"type": "date"},
+                "updated_at": {"type": "date"},
+            }
+        },
+        "settings": {
+            "number_of_shards": 1,
+            "number_of_replicas": 0,
+            "analysis": {
+                "normalizer": {
+                    "lowercase": {
+                        "type": "custom",
+                        "filter": ["lowercase"],
+                    }
+                }
+            },
+        },
+    }
+
+
+class GlossaryStore:
+    """Elasticsearch store for glossary term vector + keyword search."""
+
+    def __init__(
+        self,
+        client: AsyncElasticsearch,
+        index_name: str,
+        embedding_dims: int,
+    ) -> None:
+        self._client = client
+        self._index_name = index_name
+        self._embedding_dims = embedding_dims
+
+    async def ensure_index(self) -> None:
+        """Create the glossary index if it does not exist."""
+        exists = await self._client.indices.exists(index=self._index_name)
+        if not exists:
+            mapping = get_glossary_index_mapping(self._embedding_dims)
+            await self._client.indices.create(index=self._index_name, body=mapping)
+            logger.info("glossary_index_created", index=self._index_name)
+
+    async def index_term(
+        self,
+        term_id: UUID,
+        canonical: str,
+        aliases: list[str],
+        definition: str,
+        embedding: list[float],
+        category: str,
+        project_id: UUID | None = None,
+    ) -> None:
+        """Index a glossary term for kNN + keyword search."""
+        doc: dict[str, Any] = {
+            "canonical": canonical,
+            "canonical_text": canonical,
+            "aliases": [a.strip() for a in aliases if a.strip()],
+            "aliases_text": " ".join(a.strip() for a in aliases if a.strip()),
+            "definition": definition,
+            "embedding": embedding,
+            "category": category,
+        }
+        if project_id:
+            doc["project_id"] = str(project_id)
+
+        await self._client.index(
+            index=self._index_name,
+            id=str(term_id),
+            document=doc,
+            refresh="wait_for",
+        )
+
+    async def search(
+        self,
+        query_embedding: list[float],
+        project_id: UUID | None = None,
+        category: str | None = None,
+        top_k: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Semantic kNN search for glossary terms."""
+        if top_k < 1 or top_k > 100:
+            top_k = min(max(top_k, 1), 100)
+
+        filters: list[dict] = []
+        if project_id:
+            filters.append({"term": {"project_id": str(project_id)}})
+        if category:
+            filters.append({"term": {"category": category}})
+
+        knn: dict[str, Any] = {
+            "field": "embedding",
+            "query_vector": query_embedding,
+            "k": top_k,
+            "num_candidates": top_k * 10,
+        }
+        if filters:
+            knn["filter"] = {"bool": {"must": filters}}
+
+        result = await self._client.search(
+            index=self._index_name,
+            knn=knn,
+            size=top_k,
+        )
+
+        return [
+            {
+                "term_id": hit["_id"],
+                "score": hit["_score"],
+                "canonical": hit["_source"].get("canonical", ""),
+                "aliases": hit["_source"].get("aliases", []),
+                "definition": hit["_source"].get("definition", ""),
+                "category": hit["_source"].get("category", ""),
+            }
+            for hit in result["hits"]["hits"]
+        ]
+
+    async def search_by_alias(
+        self,
+        alias: str,
+        project_id: UUID | None = None,
+        top_k: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Keyword search on canonical + aliases fields (case-insensitive).
+
+        Uses multi_match across keyword (exact, lowercased) and text (analyzed) fields.
+        """
+        filters: list[dict] = []
+        if project_id:
+            filters.append({"term": {"project_id": str(project_id)}})
+
+        query: dict[str, Any] = {
+            "bool": {
+                "should": [
+                    {"term": {"canonical": alias.lower()}},
+                    {"term": {"aliases": alias.lower()}},
+                    {"match": {"canonical_text": {"query": alias, "boost": 2.0}}},
+                    {"match": {"aliases_text": {"query": alias, "boost": 1.5}}},
+                    {"match": {"definition": {"query": alias, "boost": 0.5}}},
+                ],
+                "minimum_should_match": 1,
+            }
+        }
+        if filters:
+            query["bool"]["filter"] = filters
+
+        result = await self._client.search(
+            index=self._index_name,
+            query=query,
+            size=top_k,
+        )
+
+        return [
+            {
+                "term_id": hit["_id"],
+                "score": hit["_score"],
+                "canonical": hit["_source"].get("canonical", ""),
+                "aliases": hit["_source"].get("aliases", []),
+                "definition": hit["_source"].get("definition", ""),
+                "category": hit["_source"].get("category", ""),
+            }
+            for hit in result["hits"]["hits"]
+        ]
+
+    async def find_duplicates(
+        self,
+        embedding: list[float],
+        project_id: UUID | None,
+        threshold: float = 0.92,
+    ) -> list[dict[str, Any]]:
+        """Find semantically similar terms for dedup check."""
+        filters: list[dict] = []
+        if project_id:
+            filters.append({"term": {"project_id": str(project_id)}})
+
+        normalized_threshold = (1.0 + threshold) / 2.0
+        knn: dict[str, Any] = {
+            "field": "embedding",
+            "query_vector": embedding,
+            "k": 5,
+            "num_candidates": 50,
+            "similarity": normalized_threshold,
+        }
+        if filters:
+            knn["filter"] = {"bool": {"must": filters}}
+
+        result = await self._client.search(
+            index=self._index_name,
+            knn=knn,
+            size=5,
+        )
+
+        return [
+            {
+                "term_id": hit["_id"],
+                "score": hit["_score"],
+                "canonical": hit["_source"].get("canonical", ""),
+            }
+            for hit in result["hits"]["hits"]
+        ]
+
+    async def delete(self, term_id: UUID) -> None:
+        """Remove a term from the ES index. Tolerates missing docs."""
+        await self._client.options(ignore_status=404).delete(
+            index=self._index_name,
+            id=str(term_id),
+            refresh="wait_for",
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/glossary/test_store.py::test_glossary_index_mapping_structure -v`
+Expected: PASS
+
+- [ ] **Step 5: Write remaining store tests**
+
+Add to `tests/glossary/test_store.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_ensure_index_creates_when_missing(glossary_store, mock_es_client):
+    """ensure_index creates the index when it doesn't exist."""
+    mock_es_client.indices.exists.return_value = False
+
+    await glossary_store.ensure_index()
+
+    mock_es_client.indices.create.assert_awaited_once()
+    call_kwargs = mock_es_client.indices.create.call_args
+    assert call_kwargs.kwargs["index"] == "test_glossary"
+
+
+@pytest.mark.asyncio
+async def test_ensure_index_skips_when_exists(glossary_store, mock_es_client):
+    """ensure_index is a no-op when index already exists."""
+    mock_es_client.indices.exists.return_value = True
+
+    await glossary_store.ensure_index()
+
+    mock_es_client.indices.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_index_term(glossary_store, mock_es_client):
+    """index_term indexes a glossary term in ES."""
+    term_id = uuid.uuid4()
+    embedding = [0.1] * 1536
+
+    await glossary_store.index_term(
+        term_id=term_id,
+        canonical="Gross Bookings",
+        aliases=["GBs", "gross books"],
+        definition="Total fare amount before deductions",
+        embedding=embedding,
+        category="metric",
+        project_id=uuid.uuid4(),
+    )
+
+    mock_es_client.index.assert_awaited_once()
+    call_kwargs = mock_es_client.index.call_args.kwargs
+    assert call_kwargs["index"] == "test_glossary"
+    assert call_kwargs["id"] == str(term_id)
+    assert call_kwargs["document"]["canonical"] == "Gross Bookings"
+    assert call_kwargs["document"]["aliases"] == ["GBs", "gross books"]
+
+
+@pytest.mark.asyncio
+async def test_search_terms(glossary_store, mock_es_client):
+    """search returns scored term IDs from kNN search."""
+    term_id = uuid.uuid4()
+    mock_es_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": str(term_id),
+                    "_score": 0.95,
+                    "_source": {
+                        "canonical": "Gross Bookings",
+                        "aliases": ["GBs"],
+                        "definition": "Total fare amount",
+                        "category": "metric",
+                    },
+                }
+            ]
+        }
+    }
+
+    results = await glossary_store.search(
+        query_embedding=[0.1] * 1536,
+        top_k=5,
+    )
+
+    assert len(results) == 1
+    assert results[0]["canonical"] == "Gross Bookings"
+    assert results[0]["score"] == 0.95
+
+
+@pytest.mark.asyncio
+async def test_search_by_alias(glossary_store, mock_es_client):
+    """search_by_alias finds terms by keyword match on canonical/aliases."""
+    term_id = uuid.uuid4()
+    mock_es_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_id": str(term_id),
+                    "_score": 8.5,
+                    "_source": {
+                        "canonical": "Gross Bookings",
+                        "aliases": ["GBs", "gross books"],
+                        "definition": "Total fare amount",
+                        "category": "metric",
+                    },
+                }
+            ]
+        }
+    }
+
+    results = await glossary_store.search_by_alias(alias="GBs")
+
+    assert len(results) == 1
+    assert results[0]["canonical"] == "Gross Bookings"
+    mock_es_client.search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_term(glossary_store, mock_es_client):
+    """delete removes a term from ES."""
+    term_id = uuid.uuid4()
+    options_mock = mock_es_client.options.return_value
+
+    await glossary_store.delete(term_id)
+
+    mock_es_client.options.assert_called_once_with(ignore_status=404)
+    options_mock.delete.assert_awaited_once()
+```
+
+- [ ] **Step 6: Run all store tests**
+
+Run: `python -m pytest tests/glossary/test_store.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pam/glossary/__init__.py src/pam/glossary/store.py tests/glossary/conftest.py tests/glossary/test_store.py
+git commit -m "feat(glossary): add GlossaryStore ES index with kNN + keyword search"
+```
+
+---
+
+## Task 5: GlossaryService (CRUD + Semantic Search)
+
+**Files:**
+- Create: `src/pam/glossary/service.py`
+- Test: `tests/glossary/test_service.py` (add service tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/glossary/test_service.py`:
+
+```python
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pam.glossary.service import GlossaryService
+from pam.common.models import GlossaryTerm
+
+
+@pytest.mark.asyncio
+async def test_add_term_no_duplicate(mock_session_factory, mock_store, mock_embedder):
+    """add() inserts a new term when no duplicate exists."""
+    mock_store.find_duplicates.return_value = []
+
+    mock_session = AsyncMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+
+    service = GlossaryService(
+        session_factory=mock_session_factory,
+        store=mock_store,
+        embedder=mock_embedder,
+        dedup_threshold=0.92,
+    )
+
+    result = await service.add(
+        canonical="Gross Bookings",
+        aliases=["GBs", "gross books"],
+        definition="Total fare amount before deductions",
+        category="metric",
+    )
+
+    assert result is not None
+    assert result.canonical == "Gross Bookings"
+    assert result.category == "metric"
+    mock_embedder.embed_texts.assert_awaited_once()
+    mock_store.index_term.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_add_term_no_duplicate -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pam.glossary.service'`
+
+- [ ] **Step 3: Create GlossaryService**
+
+Create `src/pam/glossary/service.py`:
+
+```python
+"""Glossary service -- CRUD operations with semantic dedup."""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import structlog
+
+from pam.common.models import GlossaryTerm, GlossaryTermResponse, GlossarySearchResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from pam.glossary.store import GlossaryStore
+    from pam.ingestion.embedders.base import BaseEmbedder
+
+logger = structlog.get_logger()
+
+
+def _term_to_response(term: GlossaryTerm) -> GlossaryTermResponse:
+    """Convert a GlossaryTerm ORM instance to a GlossaryTermResponse."""
+    return GlossaryTermResponse(
+        id=term.id,
+        project_id=term.project_id,
+        canonical=term.canonical,
+        aliases=term.aliases if term.aliases else [],
+        definition=term.definition,
+        category=term.category,
+        metadata=term.metadata_ if isinstance(term.metadata_, dict) else {},
+        created_at=term.created_at,
+        updated_at=term.updated_at,
+    )
+
+
+class GlossaryService:
+    """Manages glossary terms with semantic dedup and alias search."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        store: GlossaryStore,
+        embedder: BaseEmbedder,
+        dedup_threshold: float = 0.92,
+    ) -> None:
+        self._session_factory = session_factory
+        self._store = store
+        self._embedder = embedder
+        self._dedup_threshold = dedup_threshold
+
+    @classmethod
+    async def create_from_settings(
+        cls,
+        session_factory: async_sessionmaker[AsyncSession],
+        es_client: object,
+        embedder: BaseEmbedder,
+        settings: object,
+    ) -> GlossaryService:
+        """Factory to create GlossaryService + GlossaryStore from app settings."""
+        from pam.glossary.store import GlossaryStore
+
+        store = GlossaryStore(
+            client=es_client,  # type: ignore[arg-type]
+            index_name=settings.glossary_index,  # type: ignore[attr-defined]
+            embedding_dims=settings.embedding_dims,  # type: ignore[attr-defined]
+        )
+        await store.ensure_index()
+        return cls(
+            session_factory=session_factory,
+            store=store,
+            embedder=embedder,
+            dedup_threshold=settings.glossary_dedup_threshold,  # type: ignore[attr-defined]
+        )
+
+    async def add(
+        self,
+        canonical: str,
+        definition: str,
+        category: str = "concept",
+        aliases: list[str] | None = None,
+        metadata: dict | None = None,
+        project_id: uuid_mod.UUID | None = None,
+    ) -> GlossaryTermResponse:
+        """Add a glossary term with semantic deduplication.
+
+        If a term with cosine similarity > threshold exists for the same project,
+        raises ValueError with the duplicate's canonical name.
+        """
+        if not canonical or not canonical.strip():
+            raise ValueError("Canonical term cannot be empty")
+        if not definition or not definition.strip():
+            raise ValueError("Definition cannot be empty")
+        canonical = canonical.strip()
+        definition = definition.strip()
+        aliases = [a.strip() for a in (aliases or []) if a.strip()]
+
+        # Embed the definition for semantic search
+        embed_text = f"{canonical}: {definition}"
+        embeddings = await self._embedder.embed_texts([embed_text])
+        embedding = embeddings[0]
+
+        # Check for duplicates
+        duplicates = await self._store.find_duplicates(
+            embedding=embedding,
+            project_id=project_id,
+            threshold=self._dedup_threshold,
+        )
+        if duplicates:
+            dup = duplicates[0]
+            raise ValueError(
+                f"A similar term already exists: '{dup['canonical']}' "
+                f"(similarity: {dup['score']:.2f}). Update the existing term instead."
+            )
+
+        # Insert new term
+        term_id = uuid_mod.uuid4()
+        now = datetime.now(tz=timezone.utc)
+        term = GlossaryTerm(
+            id=term_id,
+            project_id=project_id,
+            canonical=canonical,
+            aliases=aliases,
+            definition=definition,
+            category=category,
+            metadata_=metadata or {},
+            created_at=now,
+            updated_at=now,
+        )
+
+        async with self._session_factory() as session:
+            session.add(term)
+            await session.flush()
+            await session.commit()
+
+        # Index in ES -- rollback PG if this fails
+        try:
+            await self._store.index_term(
+                term_id=term_id,
+                canonical=canonical,
+                aliases=aliases,
+                definition=definition,
+                embedding=embedding,
+                category=category,
+                project_id=project_id,
+            )
+        except Exception:
+            from sqlalchemy import delete as sa_delete
+
+            async with self._session_factory() as rollback_session:
+                await rollback_session.execute(
+                    sa_delete(GlossaryTerm).where(GlossaryTerm.id == term_id)
+                )
+                await rollback_session.commit()
+            logger.error("glossary_es_index_failed", term_id=str(term_id), exc_info=True)
+            raise
+
+        logger.info("glossary_term_added", term_id=str(term_id), canonical=canonical)
+        return _term_to_response(term)
+
+    async def search(
+        self,
+        query: str,
+        project_id: uuid_mod.UUID | None = None,
+        category: str | None = None,
+        top_k: int = 10,
+    ) -> list[GlossarySearchResult]:
+        """Search glossary terms by semantic similarity."""
+        embeddings = await self._embedder.embed_texts([query])
+        query_embedding = embeddings[0]
+
+        hits = await self._store.search(
+            query_embedding=query_embedding,
+            project_id=project_id,
+            category=category,
+            top_k=top_k,
+        )
+
+        if not hits:
+            return []
+
+        # Fetch full term objects from PG
+        term_ids = [uuid_mod.UUID(h["term_id"]) for h in hits]
+        score_map = {h["term_id"]: h["score"] for h in hits}
+
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(GlossaryTerm).where(GlossaryTerm.id.in_(term_ids))
+            )
+            terms = result.scalars().all()
+
+        term_map = {str(t.id): t for t in terms}
+        results = []
+        for hit in hits:
+            term = term_map.get(hit["term_id"])
+            if term:
+                results.append(
+                    GlossarySearchResult(
+                        term=_term_to_response(term),
+                        score=score_map[hit["term_id"]],
+                    )
+                )
+
+        return results
+
+    async def search_by_alias(
+        self,
+        alias: str,
+        project_id: uuid_mod.UUID | None = None,
+        top_k: int = 5,
+    ) -> list[GlossarySearchResult]:
+        """Search glossary terms by keyword match on canonical/aliases."""
+        hits = await self._store.search_by_alias(
+            alias=alias,
+            project_id=project_id,
+            top_k=top_k,
+        )
+
+        if not hits:
+            return []
+
+        term_ids = [uuid_mod.UUID(h["term_id"]) for h in hits]
+        score_map = {h["term_id"]: h["score"] for h in hits}
+
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(GlossaryTerm).where(GlossaryTerm.id.in_(term_ids))
+            )
+            terms = result.scalars().all()
+
+        term_map = {str(t.id): t for t in terms}
+        results = []
+        for hit in hits:
+            term = term_map.get(hit["term_id"])
+            if term:
+                results.append(
+                    GlossarySearchResult(
+                        term=_term_to_response(term),
+                        score=score_map[hit["term_id"]],
+                    )
+                )
+
+        return results
+
+    async def get(self, term_id: uuid_mod.UUID) -> GlossaryTermResponse | None:
+        """Fetch a single term by ID."""
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(GlossaryTerm).where(GlossaryTerm.id == term_id)
+            )
+            term = result.scalars().first()
+            if term is None:
+                return None
+            return _term_to_response(term)
+
+    async def list_terms(
+        self,
+        project_id: uuid_mod.UUID | None = None,
+        category: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[GlossaryTermResponse]:
+        """List glossary terms, optionally filtered by project/category."""
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            stmt = select(GlossaryTerm).order_by(GlossaryTerm.canonical)
+            if project_id:
+                stmt = stmt.where(GlossaryTerm.project_id == project_id)
+            if category:
+                stmt = stmt.where(GlossaryTerm.category == category)
+            stmt = stmt.offset(offset).limit(limit)
+
+            result = await session.execute(stmt)
+            terms = result.scalars().all()
+            return [_term_to_response(t) for t in terms]
+
+    async def update(
+        self,
+        term_id: uuid_mod.UUID,
+        canonical: str | None = None,
+        aliases: list[str] | None = None,
+        definition: str | None = None,
+        category: str | None = None,
+        metadata: dict | None = None,
+    ) -> GlossaryTermResponse | None:
+        """Update a glossary term. Re-embeds and re-indexes if content changes."""
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(GlossaryTerm).where(GlossaryTerm.id == term_id)
+            )
+            term = result.scalars().first()
+            if term is None:
+                return None
+
+            content_changed = False
+            if canonical is not None and canonical != term.canonical:
+                term.canonical = canonical
+                content_changed = True
+            if aliases is not None:
+                term.aliases = [a.strip() for a in aliases if a.strip()]
+                content_changed = True
+            if definition is not None and definition != term.definition:
+                term.definition = definition
+                content_changed = True
+            if category is not None:
+                term.category = category
+            if metadata is not None:
+                term.metadata_ = metadata
+
+            term.updated_at = datetime.now(tz=timezone.utc)
+            await session.flush()
+            await session.commit()
+
+            response = _term_to_response(term)
+            t_canonical = term.canonical
+            t_aliases = term.aliases or []
+            t_definition = term.definition
+            t_category = term.category
+            t_project_id = term.project_id
+
+        # Re-index in ES if content changed
+        if content_changed:
+            embed_text = f"{t_canonical}: {t_definition}"
+            embeddings = await self._embedder.embed_texts([embed_text])
+            await self._store.index_term(
+                term_id=term_id,
+                canonical=t_canonical,
+                aliases=t_aliases,
+                definition=t_definition,
+                embedding=embeddings[0],
+                category=t_category,
+                project_id=t_project_id,
+            )
+
+        return response
+
+    async def delete(self, term_id: uuid_mod.UUID) -> bool:
+        """Delete a glossary term from PG and ES. Returns True if found and deleted."""
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(GlossaryTerm).where(GlossaryTerm.id == term_id)
+            )
+            term = result.scalars().first()
+            if term is None:
+                return False
+
+            await session.delete(term)
+            await session.flush()
+            await session.commit()
+
+        await self._store.delete(term_id)
+        logger.info("glossary_term_deleted", term_id=str(term_id))
+        return True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_add_term_no_duplicate -v`
+Expected: PASS
+
+- [ ] **Step 5: Write additional service tests**
+
+Add to `tests/glossary/test_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_add_term_rejects_duplicate(mock_session_factory, mock_store, mock_embedder):
+    """add() raises ValueError when a semantically similar term exists."""
+    mock_store.find_duplicates.return_value = [
+        {"term_id": str(uuid.uuid4()), "score": 0.95, "canonical": "Gross Bookings"}
+    ]
+
+    service = GlossaryService(
+        session_factory=mock_session_factory,
+        store=mock_store,
+        embedder=mock_embedder,
+    )
+
+    with pytest.raises(ValueError, match="similar term already exists"):
+        await service.add(
+            canonical="Total Bookings",
+            definition="Total fare amount before deductions",
+            category="metric",
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_term_rejects_empty_canonical(mock_session_factory, mock_store, mock_embedder):
+    """add() raises ValueError for empty canonical."""
+    service = GlossaryService(
+        session_factory=mock_session_factory,
+        store=mock_store,
+        embedder=mock_embedder,
+    )
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        await service.add(canonical="", definition="Something")
+
+
+@pytest.mark.asyncio
+async def test_search_returns_scored_results(mock_session_factory, mock_store, mock_embedder):
+    """search() returns GlossarySearchResult list."""
+    term_id = uuid.uuid4()
+    mock_store.search.return_value = [
+        {
+            "term_id": str(term_id),
+            "score": 0.9,
+            "canonical": "Gross Bookings",
+            "aliases": ["GBs"],
+            "definition": "Total fare",
+            "category": "metric",
+        }
+    ]
+
+    # Mock PG query
+    mock_term = GlossaryTerm(
+        id=term_id,
+        canonical="Gross Bookings",
+        aliases=["GBs"],
+        definition="Total fare",
+        category="metric",
+        metadata_={},
+        created_at=datetime.now(tz=timezone.utc),
+        updated_at=datetime.now(tz=timezone.utc),
+    )
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_term]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+
+    service = GlossaryService(
+        session_factory=mock_session_factory,
+        store=mock_store,
+        embedder=mock_embedder,
+    )
+
+    results = await service.search(query="gross bookings")
+
+    assert len(results) == 1
+    assert results[0].term.canonical == "Gross Bookings"
+    assert results[0].score == 0.9
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_false_when_not_found(mock_session_factory, mock_store, mock_embedder):
+    """delete() returns False when term doesn't exist."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+
+    service = GlossaryService(
+        session_factory=mock_session_factory,
+        store=mock_store,
+        embedder=mock_embedder,
+    )
+
+    result = await service.delete(uuid.uuid4())
+    assert result is False
+```
+
+- [ ] **Step 6: Run all service tests**
+
+Run: `python -m pytest tests/glossary/test_service.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pam/glossary/service.py tests/glossary/test_service.py
+git commit -m "feat(glossary): add GlossaryService with CRUD and semantic dedup"
+```
+
+---
+
+## Task 6: Alias Resolver (Query Expansion)
+
+**Files:**
+- Create: `src/pam/glossary/resolver.py`
+- Create: `tests/glossary/test_resolver.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/glossary/test_resolver.py`:
+
+```python
+"""Tests for AliasResolver query expansion."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pam.glossary.resolver import AliasResolver
+
+
+@pytest.fixture()
+def mock_glossary_store() -> AsyncMock:
+    """Mock GlossaryStore for resolver tests."""
+    store = AsyncMock()
+    store.search_by_alias = AsyncMock(return_value=[])
+    return store
+
+
+@pytest.fixture()
+def resolver(mock_glossary_store) -> AliasResolver:
+    return AliasResolver(store=mock_glossary_store)
+
+
+@pytest.mark.asyncio
+async def test_resolve_expands_known_alias(resolver, mock_glossary_store):
+    """resolve() expands known aliases to canonical terms."""
+    mock_glossary_store.search_by_alias.return_value = [
+        {
+            "term_id": "abc",
+            "score": 10.0,
+            "canonical": "Gross Bookings",
+            "aliases": ["GBs", "gross books"],
+            "definition": "Total fare amount",
+            "category": "metric",
+        }
+    ]
+
+    result = await resolver.resolve("What's the GBs target?")
+
+    assert "Gross Bookings" in result.expanded_query
+    assert len(result.resolved_terms) == 1
+    assert result.resolved_terms[0]["canonical"] == "Gross Bookings"
+    assert result.original_query == "What's the GBs target?"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/glossary/test_resolver.py::test_resolve_expands_known_alias -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pam.glossary.resolver'`
+
+- [ ] **Step 3: Create AliasResolver**
+
+Create `src/pam/glossary/resolver.py`:
+
+```python
+"""Alias resolution and query expansion using glossary terms."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from pam.glossary.store import GlossaryStore
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class ResolvedQuery:
+    """Result of alias resolution."""
+
+    original_query: str
+    expanded_query: str
+    resolved_terms: list[dict] = field(default_factory=list)
+
+
+class AliasResolver:
+    """Resolves aliases in user queries to canonical glossary terms.
+
+    Strategy:
+    1. Tokenize query into candidate words/phrases
+    2. For each candidate, search glossary aliases (keyword match)
+    3. If a match is found with score above threshold, note the expansion
+    4. Return the expanded query with resolved terms appended
+    """
+
+    def __init__(
+        self,
+        store: GlossaryStore,
+        min_score: float = 3.0,
+        project_id: UUID | None = None,
+    ) -> None:
+        self._store = store
+        self._min_score = min_score
+        self._project_id = project_id
+
+    async def resolve(
+        self,
+        query: str,
+        project_id: UUID | None = None,
+    ) -> ResolvedQuery:
+        """Resolve aliases in a query string to canonical terms.
+
+        Extracts candidate tokens from the query, searches each against
+        the glossary, and appends canonical expansions.
+        """
+        pid = project_id or self._project_id
+        candidates = self._extract_candidates(query)
+
+        if not candidates:
+            return ResolvedQuery(original_query=query, expanded_query=query)
+
+        resolved_terms: list[dict] = []
+        seen_canonicals: set[str] = set()
+
+        for candidate in candidates:
+            hits = await self._store.search_by_alias(
+                alias=candidate,
+                project_id=pid,
+                top_k=1,
+            )
+            if not hits:
+                continue
+
+            hit = hits[0]
+            if hit["score"] < self._min_score:
+                continue
+
+            canonical = hit["canonical"]
+            if canonical.lower() in seen_canonicals:
+                continue
+
+            # Verify the candidate actually matches an alias or canonical
+            all_names = [canonical.lower()] + [a.lower() for a in hit.get("aliases", [])]
+            if candidate.lower() not in all_names:
+                continue
+
+            seen_canonicals.add(canonical.lower())
+            resolved_terms.append({
+                "matched": candidate,
+                "canonical": canonical,
+                "definition": hit.get("definition", ""),
+                "category": hit.get("category", ""),
+            })
+
+        if not resolved_terms:
+            return ResolvedQuery(original_query=query, expanded_query=query)
+
+        # Build expanded query: original + glossary context
+        expansions = []
+        for rt in resolved_terms:
+            if rt["matched"].lower() != rt["canonical"].lower():
+                expansions.append(f'{rt["matched"]} (= {rt["canonical"]})')
+
+        expanded = query
+        if expansions:
+            expanded = f"{query} [Glossary: {'; '.join(expansions)}]"
+
+        logger.info(
+            "alias_resolved",
+            original=query[:100],
+            resolved_count=len(resolved_terms),
+        )
+
+        return ResolvedQuery(
+            original_query=query,
+            expanded_query=expanded,
+            resolved_terms=resolved_terms,
+        )
+
+    def _extract_candidates(self, query: str) -> list[str]:
+        """Extract candidate tokens that might be aliases.
+
+        Focuses on:
+        - Quoted terms
+        - Uppercase abbreviations (GBs, EMEA)
+        - Individual words (filtered by length and stop words)
+        """
+        candidates: list[str] = []
+        seen: set[str] = set()
+
+        def _add(token: str) -> None:
+            t = token.strip()
+            if t and t.lower() not in seen:
+                seen.add(t.lower())
+                candidates.append(t)
+
+        # Quoted terms: "Gross Bookings"
+        for match in re.finditer(r'"([^"]+)"', query):
+            _add(match.group(1))
+
+        # Uppercase abbreviations: GBs, EMEA, US&C
+        for match in re.finditer(r'\b[A-Z][A-Z&]+[a-z]?\b', query):
+            _add(match.group())
+
+        # Individual words (3+ chars, not stop words)
+        stop_words = {
+            "the", "what", "how", "why", "who", "when", "where",
+            "is", "are", "was", "were", "and", "for", "our",
+            "last", "this", "that", "with", "from", "have", "has",
+        }
+        for word in re.findall(r'\b\w+\b', query):
+            if len(word) >= 3 and word.lower() not in stop_words:
+                _add(word)
+
+        return candidates
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/glossary/test_resolver.py::test_resolve_expands_known_alias -v`
+Expected: PASS
+
+- [ ] **Step 5: Write additional resolver tests**
+
+Add to `tests/glossary/test_resolver.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_resolve_no_matches_returns_original(resolver, mock_glossary_store):
+    """resolve() returns original query when no aliases match."""
+    mock_glossary_store.search_by_alias.return_value = []
+
+    result = await resolver.resolve("What is the revenue?")
+
+    assert result.expanded_query == "What is the revenue?"
+    assert result.resolved_terms == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_skips_low_score(resolver, mock_glossary_store):
+    """resolve() skips matches below min_score threshold."""
+    mock_glossary_store.search_by_alias.return_value = [
+        {
+            "term_id": "abc",
+            "score": 1.0,  # Below default min_score of 3.0
+            "canonical": "Gross Bookings",
+            "aliases": ["GBs"],
+            "definition": "Total fare",
+            "category": "metric",
+        }
+    ]
+
+    result = await resolver.resolve("What's the GBs target?")
+
+    assert result.expanded_query == "What's the GBs target?"
+    assert result.resolved_terms == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_deduplicates_canonicals(resolver, mock_glossary_store):
+    """resolve() doesn't add the same canonical term twice."""
+    mock_glossary_store.search_by_alias.side_effect = [
+        [{"term_id": "abc", "score": 10.0, "canonical": "Gross Bookings",
+          "aliases": ["GBs"], "definition": "Total fare", "category": "metric"}],
+        [{"term_id": "abc", "score": 10.0, "canonical": "Gross Bookings",
+          "aliases": ["GBs"], "definition": "Total fare", "category": "metric"}],
+        [],
+        [],
+        [],
+    ]
+
+    result = await resolver.resolve("GBs and GBs trend")
+
+    canonical_matches = [rt["canonical"] for rt in result.resolved_terms]
+    assert canonical_matches.count("Gross Bookings") <= 1
+
+
+def test_extract_candidates_abbreviations(resolver):
+    """_extract_candidates picks up uppercase abbreviations."""
+    candidates = resolver._extract_candidates("What's the GBs in EMEA?")
+    candidate_lower = [c.lower() for c in candidates]
+    assert "gbs" in candidate_lower
+    assert "emea" in candidate_lower
+
+
+def test_extract_candidates_quoted(resolver):
+    """_extract_candidates picks up quoted terms."""
+    candidates = resolver._extract_candidates('Look up "Gross Bookings" please')
+    assert "Gross Bookings" in candidates
+
+
+def test_extract_candidates_filters_stop_words(resolver):
+    """_extract_candidates filters out stop words."""
+    candidates = resolver._extract_candidates("what is the target")
+    candidate_lower = [c.lower() for c in candidates]
+    assert "what" not in candidate_lower
+    assert "the" not in candidate_lower
+    assert "target" in candidate_lower
+```
+
+- [ ] **Step 6: Run all resolver tests**
+
+Run: `python -m pytest tests/glossary/test_resolver.py -v`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pam/glossary/resolver.py tests/glossary/test_resolver.py
+git commit -m "feat(glossary): add AliasResolver for query expansion"
+```
+
+---
+
+## Task 7: REST API Routes
+
+**Files:**
+- Create: `src/pam/api/routes/glossary.py`
+
+- [ ] **Step 1: Create the glossary routes**
+
+Create `src/pam/api/routes/glossary.py`:
+
+```python
+"""Glossary CRUD REST endpoints."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from pam.api.auth import get_current_user
+from pam.api.rate_limit import limiter
+from pam.common.config import settings
+from pam.common.models import (
+    GlossaryResolveResult,
+    GlossarySearchResult,
+    GlossaryTermCreate,
+    GlossaryTermResponse,
+    GlossaryTermUpdate,
+    User,
+)
+
+router = APIRouter()
+
+
+def get_glossary_service():
+    """Dependency stub -- overridden at app startup."""
+    raise RuntimeError("GlossaryService not initialized")
+
+
+@router.post("", response_model=GlossaryTermResponse, status_code=201)
+@limiter.limit(settings.rate_limit_default)
+async def add_term(
+    request: Request,  # noqa: ARG001
+    body: GlossaryTermCreate,
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Add a new glossary term.
+
+    Returns 409 if a semantically similar term already exists.
+    """
+    try:
+        return await glossary_service.add(
+            canonical=body.canonical,
+            aliases=body.aliases,
+            definition=body.definition,
+            category=body.category,
+            metadata=body.metadata,
+            project_id=body.project_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.get("/search", response_model=list[GlossarySearchResult])
+@limiter.limit(settings.rate_limit_search)
+async def search_terms(
+    request: Request,  # noqa: ARG001
+    query: str,
+    project_id: uuid.UUID | None = None,
+    category: str | None = None,
+    top_k: int = Query(default=10, ge=1, le=50),
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Semantic search across glossary terms."""
+    return await glossary_service.search(
+        query=query,
+        project_id=project_id,
+        category=category,
+        top_k=top_k,
+    )
+
+
+@router.post("/resolve", response_model=GlossaryResolveResult)
+@limiter.limit(settings.rate_limit_search)
+async def resolve_aliases(
+    request: Request,  # noqa: ARG001
+    query: str,
+    project_id: uuid.UUID | None = None,
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Resolve aliases in a query string to canonical glossary terms.
+
+    Returns the expanded query with resolved terms noted.
+    """
+    from pam.glossary.resolver import AliasResolver
+
+    resolver = AliasResolver(
+        store=glossary_service._store,
+        project_id=project_id,
+    )
+    result = await resolver.resolve(query=query, project_id=project_id)
+    return GlossaryResolveResult(
+        original_query=result.original_query,
+        expanded_query=result.expanded_query,
+        resolved_terms=result.resolved_terms,
+    )
+
+
+@router.get("", response_model=list[GlossaryTermResponse])
+@limiter.limit(settings.rate_limit_default)
+async def list_terms(
+    request: Request,  # noqa: ARG001
+    project_id: uuid.UUID | None = None,
+    category: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """List glossary terms, optionally filtered by project and category."""
+    return await glossary_service.list_terms(
+        project_id=project_id,
+        category=category,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{term_id}", response_model=GlossaryTermResponse)
+@limiter.limit(settings.rate_limit_default)
+async def get_term(
+    request: Request,  # noqa: ARG001
+    term_id: uuid.UUID,
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Get a specific glossary term by ID."""
+    result = await glossary_service.get(term_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Glossary term not found")
+    return result
+
+
+@router.patch("/{term_id}", response_model=GlossaryTermResponse)
+@limiter.limit(settings.rate_limit_default)
+async def update_term(
+    request: Request,  # noqa: ARG001
+    term_id: uuid.UUID,
+    body: GlossaryTermUpdate,
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Update a glossary term's fields."""
+    result = await glossary_service.update(
+        term_id=term_id,
+        canonical=body.canonical,
+        aliases=body.aliases,
+        definition=body.definition,
+        category=body.category,
+        metadata=body.metadata,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Glossary term not found")
+    return result
+
+
+@router.delete("/{term_id}")
+@limiter.limit(settings.rate_limit_default)
+async def delete_term(
+    request: Request,  # noqa: ARG001
+    term_id: uuid.UUID,
+    glossary_service=Depends(get_glossary_service),
+    _user: User | None = Depends(get_current_user),
+):
+    """Delete a glossary term."""
+    deleted = await glossary_service.delete(term_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Glossary term not found")
+    return {"message": "Glossary term deleted", "id": str(term_id)}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `python -m py_compile src/pam/api/routes/glossary.py`
+Expected: No output (clean compile)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pam/api/routes/glossary.py
+git commit -m "feat(glossary): add REST API routes for glossary CRUD + resolve"
+```
+
+---
+
+## Task 8: App Startup Wiring
+
+**Files:**
+- Modify: `src/pam/api/main.py`
+- Modify: `src/pam/mcp/services.py`
+
+- [ ] **Step 1: Add glossary_service to PamServices**
+
+In `src/pam/mcp/services.py`, add to the TYPE_CHECKING imports:
+
+```python
+    from pam.glossary.service import GlossaryService
+```
+
+Add field to PamServices dataclass (after `conversation_service`):
+
+```python
+    glossary_service: GlossaryService | None
+```
+
+Update `from_app_state()` to include:
+
+```python
+        glossary_service=getattr(app_state, "glossary_service", None),
+```
+
+- [ ] **Step 2: Wire GlossaryService in main.py lifespan**
+
+In `src/pam/api/main.py`, update the routes import to include `glossary`:
+
+```python
+from pam.api.routes import admin, auth, chat, conversation, documents, glossary, graph, ingest, memory, search
+```
+
+In the lifespan function, add after the Conversation Service block (after the `except Exception:` that catches conversation init failures):
+
+```python
+    # --- Glossary Service ---
+    try:
+        from pam.glossary.service import GlossaryService
+
+        glossary_service = await GlossaryService.create_from_settings(
+            session_factory=session_factory,
+            es_client=app.state.es_client,
+            embedder=app.state.embedder,
+            settings=settings,
+        )
+        app.state.glossary_service = glossary_service
+        logger.info("glossary_service_initialized")
+    except Exception:
+        app.state.glossary_service = None
+        logger.warning("glossary_service_init_failed", exc_info=True)
+```
+
+In `create_app()`, add the router after the conversation router:
+
+```python
+    app.include_router(glossary.router, prefix="/api/glossary", tags=["glossary"])
+```
+
+Add the dependency override after the conversation override block:
+
+```python
+    # Override the glossary service dependency
+    from pam.api.routes.glossary import get_glossary_service as _get_glossary_svc
+
+    def _glossary_svc_override():
+        svc = getattr(app.state, "glossary_service", None)
+        if svc is None:
+            raise RuntimeError("GlossaryService not initialized")
+        return svc
+
+    app.dependency_overrides[_get_glossary_svc] = _glossary_svc_override
+```
+
+- [ ] **Step 3: Verify the app compiles**
+
+Run: `python -c "from pam.api.main import create_app; print('OK')"`
+Expected: `OK` (may fail if env vars are missing, but no import errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pam/api/main.py src/pam/mcp/services.py
+git commit -m "feat(glossary): wire GlossaryService into app startup and DI"
+```
+
+---
+
+## Task 9: MCP Tools + Resource
+
+**Files:**
+- Modify: `src/pam/mcp/server.py`
+
+- [ ] **Step 1: Add glossary tool registration call**
+
+In `create_mcp_server()`, add a call to `_register_glossary_tools(mcp)` before `_register_resources(mcp)`:
+
+```python
+    _register_glossary_tools(mcp)
+```
+
+Update the instructions string to mention glossary:
+
+```python
+    mcp = FastMCP(
+        "PAM Context",
+        instructions=(
+            "Business Knowledge Layer for LLMs -- search documents, query knowledge graph, "
+            "trigger ingestion, store and recall memories, manage domain glossary"
+        ),
+    )
+```
+
+- [ ] **Step 2: Add the glossary tool registration function**
+
+Add before `_register_resources`:
+
+```python
+def _register_glossary_tools(mcp: FastMCP) -> None:
+    """Register glossary MCP tools."""
+
+    @mcp.tool()
+    async def pam_glossary_add(
+        canonical: str,
+        definition: str,
+        category: str = "concept",
+        aliases: list[str] | None = None,
+        project_id: str | None = None,
+    ) -> str:
+        """Add a new term to PAM's glossary.
+
+        Stores a domain term with its canonical name, definition, aliases, and category.
+        Deduplicates: if a semantically similar term exists, returns an error.
+
+        category: metric, team, product, acronym, concept, or other.
+        aliases: alternative names/abbreviations (e.g., ["GBs", "gross books"]).
+        """
+        return await _pam_glossary_add(
+            canonical=canonical,
+            definition=definition,
+            category=category,
+            aliases=aliases,
+            project_id=project_id,
+        )
+
+    @mcp.tool()
+    async def pam_glossary_search(
+        query: str,
+        top_k: int = 10,
+        project_id: str | None = None,
+        category: str | None = None,
+    ) -> str:
+        """Search PAM's glossary for domain terminology.
+
+        Returns terms ranked by semantic similarity to the query.
+        """
+        return await _pam_glossary_search(
+            query=query,
+            top_k=top_k,
+            project_id=project_id,
+            category=category,
+        )
+
+    @mcp.tool()
+    async def pam_glossary_resolve(
+        query: str,
+        project_id: str | None = None,
+    ) -> str:
+        """Resolve aliases in a query string using PAM's glossary.
+
+        Expands abbreviations and aliases to their canonical forms.
+        Example: "What's the GBs target?" expands GBs to Gross Bookings.
+        """
+        return await _pam_glossary_resolve(query=query, project_id=project_id)
+```
+
+- [ ] **Step 3: Add the implementation functions**
+
+Add after the `_register_glossary_tools` function:
+
+```python
+async def _pam_glossary_add(
+    canonical: str,
+    definition: str,
+    category: str = "concept",
+    aliases: list[str] | None = None,
+    project_id: str | None = None,
+) -> str:
+    """Implementation of pam_glossary_add."""
+    import uuid as uuid_mod
+
+    services = get_services()
+    if services.glossary_service is None:
+        return json.dumps({"error": "Glossary service is unavailable"})
+
+    try:
+        parsed_project_id = uuid_mod.UUID(project_id) if project_id else None
+    except ValueError:
+        return json.dumps({"error": f"Invalid project_id: {project_id}"})
+
+    try:
+        result = await services.glossary_service.add(
+            canonical=canonical,
+            definition=definition,
+            category=category,
+            aliases=aliases or [],
+            project_id=parsed_project_id,
+        )
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    return json.dumps(
+        {
+            "id": str(result.id),
+            "canonical": result.canonical,
+            "aliases": result.aliases,
+            "definition": result.definition,
+            "category": result.category,
+            "created_at": result.created_at.isoformat() if result.created_at else None,
+        },
+        indent=2,
+    )
+
+
+async def _pam_glossary_search(
+    query: str,
+    top_k: int = 10,
+    project_id: str | None = None,
+    category: str | None = None,
+) -> str:
+    """Implementation of pam_glossary_search."""
+    import uuid as uuid_mod
+
+    services = get_services()
+    if services.glossary_service is None:
+        return json.dumps({"error": "Glossary service is unavailable"})
+
+    try:
+        parsed_project_id = uuid_mod.UUID(project_id) if project_id else None
+    except ValueError:
+        return json.dumps({"error": f"Invalid project_id: {project_id}"})
+
+    results = await services.glossary_service.search(
+        query=query,
+        project_id=parsed_project_id,
+        category=category,
+        top_k=top_k,
+    )
+
+    return json.dumps(
+        {
+            "terms": [
+                {
+                    "id": str(r.term.id),
+                    "canonical": r.term.canonical,
+                    "aliases": r.term.aliases,
+                    "definition": r.term.definition,
+                    "category": r.term.category,
+                    "score": r.score,
+                }
+                for r in results
+            ],
+            "count": len(results),
+        },
+        indent=2,
+    )
+
+
+async def _pam_glossary_resolve(
+    query: str,
+    project_id: str | None = None,
+) -> str:
+    """Implementation of pam_glossary_resolve."""
+    import uuid as uuid_mod
+
+    services = get_services()
+    if services.glossary_service is None:
+        return json.dumps({"error": "Glossary service is unavailable"})
+
+    try:
+        parsed_project_id = uuid_mod.UUID(project_id) if project_id else None
+    except ValueError:
+        return json.dumps({"error": f"Invalid project_id: {project_id}"})
+
+    from pam.glossary.resolver import AliasResolver
+
+    resolver = AliasResolver(
+        store=services.glossary_service._store,
+        project_id=parsed_project_id,
+    )
+    result = await resolver.resolve(query=query, project_id=parsed_project_id)
+
+    return json.dumps(
+        {
+            "original_query": result.original_query,
+            "expanded_query": result.expanded_query,
+            "resolved_terms": result.resolved_terms,
+        },
+        indent=2,
+    )
+```
+
+- [ ] **Step 4: Add pam://glossary resource**
+
+In the `_register_resources` function, add after the existing entity resources:
+
+```python
+    @mcp.resource("pam://glossary")
+    async def glossary_resource() -> str:
+        """Domain glossary -- curated terminology with aliases and definitions."""
+        return await _get_glossary()
+```
+
+Add the implementation function:
+
+```python
+async def _get_glossary() -> str:
+    """Implementation of pam://glossary resource."""
+    services = get_services()
+    if services.glossary_service is None:
+        return json.dumps({"terms": [], "error": "Glossary service is unavailable"})
+
+    terms = await services.glossary_service.list_terms(limit=100)
+
+    return json.dumps(
+        {
+            "terms": [
+                {
+                    "canonical": t.canonical,
+                    "aliases": t.aliases,
+                    "definition": t.definition,
+                    "category": t.category,
+                }
+                for t in terms
+            ],
+            "count": len(terms),
+        },
+        indent=2,
+    )
+```
+
+- [ ] **Step 5: Verify syntax**
+
+Run: `python -m py_compile src/pam/mcp/server.py`
+Expected: No output (clean compile)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pam/mcp/server.py
+git commit -m "feat(glossary): add MCP tools pam_glossary_add/search/resolve + pam://glossary resource"
+```
+
+---
+
+## Task 10: Context Assembly Integration
+
+**Files:**
+- Modify: `src/pam/agent/context_assembly.py`
+- Test: `tests/glossary/test_service.py` (add context tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/glossary/test_service.py`:
+
+```python
+def test_context_budget_includes_glossary():
+    """ContextBudget has a glossary_tokens field."""
+    from pam.agent.context_assembly import ContextBudget
+
+    budget = ContextBudget()
+    assert hasattr(budget, "glossary_tokens")
+    assert budget.glossary_tokens > 0
+
+
+def test_assembled_context_includes_glossary():
+    """AssembledContext has glossary_tokens_used field."""
+    from pam.agent.context_assembly import AssembledContext
+
+    ctx = AssembledContext(
+        text="test",
+        entity_tokens_used=0,
+        relationship_tokens_used=0,
+        chunk_tokens_used=0,
+        total_tokens=0,
+        glossary_tokens_used=100,
+    )
+    assert ctx.glossary_tokens_used == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_context_budget_includes_glossary -v`
+Expected: FAIL with `AttributeError`
+
+- [ ] **Step 3: Add glossary_tokens to ContextBudget**
+
+In `src/pam/agent/context_assembly.py`, update `ContextBudget`:
+
+```python
+@dataclass
+class ContextBudget:
+    """Token budget configuration for context assembly."""
+
+    entity_tokens: int = 4000
+    relationship_tokens: int = 6000
+    max_total_tokens: int = 17000
+    max_item_tokens: int = 500
+    memory_tokens: int = 2000
+    conversation_tokens: int = 2000
+    glossary_tokens: int = 1000
+```
+
+- [ ] **Step 4: Add glossary_tokens_used to AssembledContext**
+
+```python
+@dataclass
+class AssembledContext:
+    """Result of the context assembly pipeline."""
+
+    text: str
+    entity_tokens_used: int
+    relationship_tokens_used: int
+    chunk_tokens_used: int
+    total_tokens: int
+    memory_tokens_used: int = 0
+    conversation_tokens_used: int = 0
+    glossary_tokens_used: int = 0
+```
+
+- [ ] **Step 5: Update _build_context_string to accept glossary**
+
+Add `glossary_terms: list[dict] | None = None` parameter. Add detection:
+
+```python
+    has_glossary = bool(glossary_terms)
+```
+
+Update the all-empty check to include `has_glossary`. Add to summary_bits:
+
+```python
+    if has_glossary:
+        summary_bits.append(f"{len(glossary_terms)} glossary terms")
+```
+
+Add glossary section rendering (after User Memories, before Recent Conversation):
+
+```python
+    # --- Glossary Terms ---
+    if has_glossary:
+        parts.append("## Domain Glossary")
+        for g in glossary_terms:
+            canonical = g.get("canonical", "")
+            definition = g.get("definition", "")
+            aliases = g.get("aliases", [])
+            alias_str = f" (aka {', '.join(aliases)})" if aliases else ""
+            parts.append(f"- **{canonical}**{alias_str}: {definition}")
+        parts.append("")
+```
+
+- [ ] **Step 6: Update assemble_context to handle glossary**
+
+Add `glossary_results: list[dict] | None = None` parameter. After conversation truncation, add:
+
+```python
+    # ---- Glossary truncation ----
+    glossary_results = glossary_results or []
+    glossary_sorted = sorted(glossary_results, key=lambda x: x.get("score", 0), reverse=True)
+    glossary_truncated, glossary_tokens_used, _ = truncate_list_by_token_budget(
+        glossary_sorted, "definition", budget.glossary_tokens, budget.max_item_tokens,
+    )
+```
+
+Update chunk_budget to subtract glossary tokens:
+
+```python
+    chunk_budget = _calculate_chunk_budget(
+        budget.max_total_tokens - memory_tokens_used - conversation_tokens_used - glossary_tokens_used,
+        budget.entity_tokens,
+        budget.relationship_tokens,
+        entity_tokens_used,
+        relationship_tokens_used,
+    )
+```
+
+Pass `glossary_terms=glossary_truncated if glossary_truncated else None` to `_build_context_string`.
+
+Update total_tokens:
+
+```python
+    total_tokens = (
+        entity_tokens_used + relationship_tokens_used + chunk_tokens_used
+        + memory_tokens_used + conversation_tokens_used + glossary_tokens_used
+    )
+```
+
+Add glossary to the logger.debug call and set `glossary_tokens_used` in the return.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `python -m pytest tests/glossary/test_service.py::test_context_budget_includes_glossary tests/glossary/test_service.py::test_assembled_context_includes_glossary -v`
+Expected: PASS
+
+- [ ] **Step 8: Run existing context assembly tests for regressions**
+
+Run: `python -m pytest tests/test_agent/test_context_assembly.py -v`
+Expected: All PASS (existing callers don't pass `glossary_results`, default `None` is used)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pam/agent/context_assembly.py tests/glossary/test_service.py
+git commit -m "feat(glossary): add glossary token budget and section to context assembly"
+```
+
+---
+
+## Task 11: Agent Integration (Query Expansion Before Search)
+
+**Files:**
+- Modify: `src/pam/agent/agent.py`
+- Modify: `src/pam/api/deps.py`
+
+- [ ] **Step 1: Add glossary_service to RetrievalAgent**
+
+In `src/pam/agent/agent.py`, add to TYPE_CHECKING imports:
+
+```python
+    from pam.glossary.service import GlossaryService
+```
+
+Add `glossary_service` parameter to `__init__` (after the last existing optional parameter):
+
+```python
+        glossary_service: GlossaryService | None = None,
+```
+
+Store it:
+
+```python
+        self.glossary_service = glossary_service
+```
+
+- [ ] **Step 2: Add alias resolution to _smart_search**
+
+In the `_smart_search` method, add alias resolution after Step A (keyword extraction) and before Step A2 (mode classification). Insert:
+
+```python
+        # Step A1: Resolve glossary aliases
+        resolved_terms: list[dict] = []
+        if self.glossary_service is not None:
+            try:
+                from pam.glossary.resolver import AliasResolver
+
+                resolver = AliasResolver(store=self.glossary_service._store)
+                resolved = await resolver.resolve(query)
+                if resolved.resolved_terms:
+                    resolved_terms = resolved.resolved_terms
+                    # Enhance ES query with canonical terms for better BM25 recall
+                    expansions = [rt["canonical"] for rt in resolved_terms
+                                  if rt["matched"].lower() != rt["canonical"].lower()]
+                    if expansions:
+                        query = f"{query} {' '.join(expansions)}"
+                        logger.info("smart_search_query_expanded", expansions=expansions)
+            except Exception:
+                logger.warning("smart_search_alias_resolution_failed", exc_info=True)
+```
+
+- [ ] **Step 3: Pass glossary results to context assembly**
+
+In `_smart_search`, find where `assemble_context` is called. Before that call, add:
+
+```python
+            # Fetch relevant glossary terms for context
+            glossary_context: list[dict] = []
+            if resolved_terms:
+                for rt in resolved_terms:
+                    glossary_context.append({
+                        "canonical": rt["canonical"],
+                        "definition": rt.get("definition", ""),
+                        "aliases": [],
+                        "score": 1.0,
+                    })
+```
+
+Then add `glossary_results=glossary_context if glossary_context else None` to the `assemble_context()` call.
+
+- [ ] **Step 4: Wire glossary_service in agent dependency**
+
+In `src/pam/api/deps.py`, find the function that creates the agent (likely `get_agent`). Add `glossary_service` to the agent constructor call:
+
+```python
+    glossary_service=getattr(request.app.state, "glossary_service", None),
+```
+
+- [ ] **Step 5: Run existing agent tests for regressions**
+
+Run: `python -m pytest tests/test_agent/ -v --no-header 2>&1 | tail -20`
+Expected: All existing tests PASS (glossary_service defaults to None)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pam/agent/agent.py src/pam/api/deps.py
+git commit -m "feat(glossary): integrate alias resolution into agent smart_search"
+```
+
+---
+
+## Task 12: Module Exports + Final Verification
+
+**Files:**
+- Modify: `src/pam/glossary/__init__.py`
+
+- [ ] **Step 1: Update __init__.py with re-exports**
+
+```python
+"""Glossary / Semantic Metadata Layer -- curated domain terminology."""
+
+from pam.glossary.resolver import AliasResolver
+from pam.glossary.service import GlossaryService
+from pam.glossary.store import GlossaryStore
+
+__all__ = ["AliasResolver", "GlossaryService", "GlossaryStore"]
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `python -m pytest tests/ -v --no-header 2>&1 | tail -40`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run linting**
+
+Run: `ruff check src/pam/glossary/ tests/glossary/ src/pam/api/routes/glossary.py`
+Expected: No errors (or fix any that appear)
+
+- [ ] **Step 4: Verify the app starts cleanly**
+
+Run: `python -c "from pam.api.main import create_app; app = create_app(); print('App created:', app.title)"`
+Expected: `App created: PAM Context API`
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add src/pam/glossary/__init__.py
+git commit -m "feat(glossary): add module re-exports and finalize Phase 4"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ extend-immutable-calls = ["fastapi.Depends", "fastapi.Query", "fastapi.Path", "f
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 asyncio_mode = "auto"
 markers = [
     "integration: marks tests requiring external services (ES, PG)",

--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -97,7 +97,7 @@ def _truncate_history(messages: list[dict], max_chars: int = MAX_HISTORY_CHARS) 
             total -= _content_len(trimmed.pop(0))
 
     # Ensure the first message is a "user" message (Anthropic API requirement)
-    while len(trimmed) > 1 and trimmed[0].get("role") != "user":
+    while trimmed and trimmed[0].get("role") != "user":
         trimmed.pop(0)
 
     return trimmed

--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+import uuid
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
@@ -149,6 +150,11 @@ class RetrievalAgent:
         # Do NOT share a single RetrievalAgent across concurrent requests.
         self._default_source_type: str | None = None
         self._last_classification: ClassificationResult | None = None
+        # Optional services for memory/conversation injection (set per-request by chat endpoint)
+        self._memory_service = None  # type: ignore[assignment]
+        self._conversation_service = None  # type: ignore[assignment]
+        self._current_user_id: uuid.UUID | None = None
+        self._current_conversation_id: uuid.UUID | None = None
 
     async def answer(
         self,
@@ -636,11 +642,40 @@ class RetrievalAgent:
             )
             citations.append(citation)
 
+        # Step F-pre: Fetch user memories and conversation context (if available)
+        memory_results: list[dict] = []
+        conversation_context = ""
+
+        if self._memory_service and self._current_user_id:
+            try:
+                raw_memories = await self._memory_service.search(
+                    query=query,
+                    user_id=self._current_user_id,
+                    top_k=5,
+                )
+                memory_results = [
+                    {"content": m.memory.content, "type": m.memory.type, "score": m.score}
+                    for m in raw_memories
+                ]
+            except Exception:
+                logger.warning("smart_search_memory_failed", exc_info=True)
+
+        if self._conversation_service and self._current_conversation_id:
+            try:
+                conversation_context = await self._conversation_service.get_recent_context(
+                    self._current_conversation_id,
+                    max_tokens=settings.conversation_context_max_tokens,
+                )
+            except Exception:
+                logger.warning("smart_search_conversation_failed", exc_info=True)
+
         # Step F: Assemble structured context with token budgets
         budget = ContextBudget(
             entity_tokens=settings.context_entity_budget,
             relationship_tokens=settings.context_relationship_budget,
             max_total_tokens=settings.context_max_tokens,
+            memory_tokens=settings.context_memory_budget,
+            conversation_tokens=settings.conversation_context_max_tokens,
         )
         assembled = assemble_context(
             es_results=es_results,
@@ -648,6 +683,8 @@ class RetrievalAgent:
             entity_vdb_results=entity_vdb_results,
             rel_vdb_results=rel_vdb_results,
             budget=budget,
+            memory_results=memory_results,
+            conversation_context=conversation_context,
         )
 
         # Step G: Build final output with keywords header + assembled context

--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -92,8 +92,8 @@ def _truncate_history(messages: list[dict], max_chars: int = MAX_HISTORY_CHARS) 
     trimmed = list(messages)
     while len(trimmed) > 1 and total > max_chars:
         total -= _content_len(trimmed.pop(0))
-        # Always drop the paired message to maintain user/assistant alternation
-        if len(trimmed) > 1:
+        # Drop the paired message only if still over budget, to maintain alternation
+        if len(trimmed) > 1 and total > max_chars:
             total -= _content_len(trimmed.pop(0))
 
     # Ensure the first message is a "user" message (Anthropic API requirement)

--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -170,8 +170,12 @@ class RetrievalAgent:
         self._default_source_type = source_type
         start = time.perf_counter()
         messages = list(conversation_history or [])
-        messages = _truncate_history(messages)
+        # Append the current user question BEFORE truncation so it is always
+        # preserved as the last message, and _truncate_history's "keep at least
+        # one message" invariant guarantees the current turn survives even if
+        # a single oversized prior message would otherwise trim the list to [].
         messages.append({"role": "user", "content": question})
+        messages = _truncate_history(messages)
 
         all_citations: list[Citation] = []
         total_input_tokens = 0
@@ -304,8 +308,12 @@ class RetrievalAgent:
         self._default_source_type = source_type
         start = time.perf_counter()
         messages = list(conversation_history or [])
-        messages = _truncate_history(messages)
+        # Append the current user question BEFORE truncation so it is always
+        # preserved as the last message, and _truncate_history's "keep at least
+        # one message" invariant guarantees the current turn survives even if
+        # a single oversized prior message would otherwise trim the list to [].
         messages.append({"role": "user", "content": question})
+        messages = _truncate_history(messages)
 
         all_citations: list[Citation] = []
         total_input_tokens = 0
@@ -446,6 +454,43 @@ class RetrievalAgent:
                 chunk += " "  # trailing space as word separator
             chunks.append(chunk)
         return chunks
+
+    async def _fetch_user_context(self, query: str) -> tuple[list[dict], str]:
+        """Fetch user memories + recent conversation context for the current request.
+
+        Returns ``(memory_results, conversation_context)``. Both tools
+        (smart_search and search_knowledge) call this so per-user memory and
+        conversation state are injected regardless of which tool the LLM picks.
+        Returns empty results when the services or per-request IDs aren't set.
+        """
+        memory_results: list[dict] = []
+        conversation_context = ""
+
+        if self._memory_service and self._current_user_id:
+            try:
+                raw_memories = await self._memory_service.search(
+                    query=query,
+                    user_id=self._current_user_id,
+                    top_k=5,
+                )
+                memory_results = [
+                    {"content": m.memory.content, "type": m.memory.type, "score": m.score}
+                    for m in raw_memories
+                ]
+            except Exception:
+                logger.warning("user_context_memory_failed", exc_info=True)
+
+        if self._conversation_service and self._current_conversation_id:
+            try:
+                settings = get_settings()
+                conversation_context = await self._conversation_service.get_recent_context(
+                    self._current_conversation_id,
+                    max_tokens=settings.conversation_context_max_tokens,
+                )
+            except Exception:
+                logger.warning("user_context_conversation_failed", exc_info=True)
+
+        return memory_results, conversation_context
 
     async def _execute_tool(self, tool_name: str, tool_input: dict) -> tuple[str, list[Citation]]:
         """Execute a tool call and return (result_text, citations)."""
@@ -643,31 +688,7 @@ class RetrievalAgent:
             citations.append(citation)
 
         # Step F-pre: Fetch user memories and conversation context (if available)
-        memory_results: list[dict] = []
-        conversation_context = ""
-
-        if self._memory_service and self._current_user_id:
-            try:
-                raw_memories = await self._memory_service.search(
-                    query=query,
-                    user_id=self._current_user_id,
-                    top_k=5,
-                )
-                memory_results = [
-                    {"content": m.memory.content, "type": m.memory.type, "score": m.score}
-                    for m in raw_memories
-                ]
-            except Exception:
-                logger.warning("smart_search_memory_failed", exc_info=True)
-
-        if self._conversation_service and self._current_conversation_id:
-            try:
-                conversation_context = await self._conversation_service.get_recent_context(
-                    self._current_conversation_id,
-                    max_tokens=settings.conversation_context_max_tokens,
-                )
-            except Exception:
-                logger.warning("smart_search_conversation_failed", exc_info=True)
+        memory_results, conversation_context = await self._fetch_user_context(query)
 
         # Step F: Assemble structured context with token budgets
         budget = ContextBudget(
@@ -709,6 +730,10 @@ class RetrievalAgent:
         query = input_["query"]
         source_type = input_.get("source_type") or self._default_source_type
 
+        # Fetch per-user memory + conversation context so they are injected
+        # regardless of which tool the LLM chose (see _fetch_user_context).
+        memory_results, conversation_context = await self._fetch_user_context(query)
+
         # Embed the query
         query_embeddings = await self.embedder.embed_texts([query])
         query_embedding = query_embeddings[0]
@@ -724,9 +749,6 @@ class RetrievalAgent:
         except SearchBackendError as exc:
             logger.warning("search_backend_error", query=query[:100], error=str(exc))
             return "Search is temporarily unavailable. Please try again.", []
-
-        if not results:
-            return "No relevant results found for this query.", []
 
         # Format results for the LLM
         citations = []
@@ -748,7 +770,20 @@ class RetrievalAgent:
             url_part = f" ({r.source_url})" if r.source_url else ""
             formatted_parts.append(f"[Result {i}] Source: {source_label}{url_part}\n{r.content}")
 
-        return "\n\n---\n\n".join(formatted_parts), citations
+        search_body = "\n\n---\n\n".join(formatted_parts) if formatted_parts else "No relevant results found for this query."
+
+        # Prepend memory + conversation sections so the LLM sees per-user context
+        # even when it chose search_knowledge over smart_search.
+        sections: list[str] = []
+        if memory_results:
+            memory_lines = [f"- [{m['type']}] {m['content']}" for m in memory_results]
+            sections.append("## User Memories\n" + "\n".join(memory_lines))
+        if conversation_context:
+            sections.append("## Recent Conversation\n" + conversation_context)
+        if sections:
+            return "\n\n".join([*sections, "## Search Results", search_body]), citations
+
+        return search_body, citations
 
     async def _get_document_context(self, input_: dict) -> tuple[str, list[Citation]]:
         """Fetch full document content by title or source_id."""

--- a/src/pam/agent/context_assembly.py
+++ b/src/pam/agent/context_assembly.py
@@ -60,7 +60,7 @@ class ContextBudget:
 
     entity_tokens: int = 4000
     relationship_tokens: int = 6000
-    max_total_tokens: int = 12000
+    max_total_tokens: int = 16000
     max_item_tokens: int = 500  # per-item description truncation cap
     memory_tokens: int = 2000
     conversation_tokens: int = 2000
@@ -147,6 +147,8 @@ def _calculate_chunk_budget(
 ) -> int:
     """Calculate the dynamic chunk budget with unused redistribution.
 
+    *max_total* is the remaining token budget after memory and conversation
+    tokens have been subtracted by the caller.
     Base chunk budget = max_total - entity_budget - relationship_budget.
     Any unused tokens from entities / relationships are added back.
     Result is floored at 0.

--- a/src/pam/agent/context_assembly.py
+++ b/src/pam/agent/context_assembly.py
@@ -62,6 +62,8 @@ class ContextBudget:
     relationship_tokens: int = 6000
     max_total_tokens: int = 12000
     max_item_tokens: int = 500  # per-item description truncation cap
+    memory_tokens: int = 2000
+    conversation_tokens: int = 2000
 
 
 @dataclass
@@ -73,6 +75,8 @@ class AssembledContext:
     relationship_tokens_used: int
     chunk_tokens_used: int
     total_tokens: int
+    memory_tokens_used: int = 0
+    conversation_tokens_used: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +165,8 @@ def _build_context_string(
     total_entities: int,
     total_relationships: int,
     total_chunks: int,
+    memories: list[dict] | None = None,
+    conversation_context: str = "",
 ) -> str:
     """Build the final structured Markdown context string.
 
@@ -170,14 +176,18 @@ def _build_context_string(
     has_entities = bool(entities)
     has_relationships = bool(relationships) or bool(graph_text.strip())
     has_chunks = bool(chunks)
+    has_memories = bool(memories)
+    has_conversation = bool(conversation_context.strip())
 
-    if not has_entities and not has_relationships and not has_chunks:
+    if not has_entities and not has_relationships and not has_chunks and not has_memories and not has_conversation:
         return "No relevant context found in knowledge base"
 
     parts: list[str] = []
 
     # --- Summary header (only mention non-empty categories) ---
     summary_bits: list[str] = []
+    if has_memories:
+        summary_bits.append(f"{len(memories)} user memories")
     if has_entities:
         summary_bits.append(f"{len(entities)} relevant entities")
     if has_relationships:
@@ -185,8 +195,25 @@ def _build_context_string(
         summary_bits.append(f"{rel_count} relationships")
     if has_chunks:
         summary_bits.append(f"{len(chunks)} document chunks")
+    if has_conversation:
+        summary_bits.append("recent conversation")
     parts.append("Found " + ", ".join(summary_bits))
     parts.append("")
+
+    # --- User Memories ---
+    if has_memories:
+        parts.append("## User Memories")
+        for m in memories:
+            mem_type = m.get("type", "fact")
+            content = m.get("content", "")
+            parts.append(f"- [{mem_type}] {content}")
+        parts.append("")
+
+    # --- Recent Conversation ---
+    if has_conversation:
+        parts.append("## Recent Conversation")
+        parts.append(conversation_context.strip())
+        parts.append("")
 
     # --- Entities ---
     if has_entities:
@@ -245,6 +272,8 @@ def assemble_context(
     entity_vdb_results: list[dict],
     rel_vdb_results: list[dict],
     budget: ContextBudget | None = None,
+    memory_results: list[dict] | None = None,
+    conversation_context: str = "",
 ) -> AssembledContext:
     """4-stage context assembly pipeline.
 
@@ -260,6 +289,10 @@ def assemble_context(
         Dicts with ``src_entity``, ``tgt_entity``, ``rel_type``, ``description``, ``score``.
     budget:
         Optional custom budget; defaults to ``ContextBudget()``.
+    memory_results:
+        Dicts with ``content``, ``type``, and ``score`` from user memory search.
+    conversation_context:
+        Pre-formatted recent conversation text.
 
     Returns
     -------
@@ -267,6 +300,24 @@ def assemble_context(
         The assembled Markdown text and per-category token usage.
     """
     budget = budget or ContextBudget()
+
+    # ---- Memory & Conversation truncation ----
+    memory_results = memory_results or []
+    memories_sorted = sorted(memory_results, key=lambda x: x.get("score", 0), reverse=True)
+    memories_truncated, memory_tokens_used, _ = truncate_list_by_token_budget(
+        memories_sorted, "content", budget.memory_tokens, budget.max_item_tokens,
+    )
+
+    conversation_tokens_used = 0
+    truncated_conversation = ""
+    if conversation_context.strip():
+        conv_tokens = count_tokens(conversation_context)
+        if conv_tokens <= budget.conversation_tokens:
+            truncated_conversation = conversation_context
+            conversation_tokens_used = conv_tokens
+        else:
+            truncated_conversation = _truncate_text_to_tokens(conversation_context, budget.conversation_tokens)
+            conversation_tokens_used = budget.conversation_tokens
 
     # ---- Stage 1: Collect & Normalize ----
     chunks: list[dict] = []
@@ -312,7 +363,7 @@ def assemble_context(
     relationship_tokens_used = rel_tokens_used + graph_text_tokens
 
     chunk_budget = _calculate_chunk_budget(
-        budget.max_total_tokens,
+        budget.max_total_tokens - memory_tokens_used - conversation_tokens_used,
         budget.entity_tokens,
         budget.relationship_tokens,
         entity_tokens_used,
@@ -338,15 +389,19 @@ def assemble_context(
         total_entities=total_entities,
         total_relationships=total_relationships,
         total_chunks=total_chunks,
+        memories=memories_truncated if memories_truncated else None,
+        conversation_context=truncated_conversation,
     )
 
-    total_tokens = entity_tokens_used + relationship_tokens_used + chunk_tokens_used
+    total_tokens = entity_tokens_used + relationship_tokens_used + chunk_tokens_used + memory_tokens_used + conversation_tokens_used
 
     logger.debug(
         "context_assembly_budget",
         entities=f"{entity_tokens_used}/{budget.entity_tokens}",
         relationships=f"{relationship_tokens_used}/{budget.relationship_tokens}",
         chunks=f"{chunk_tokens_used}/{chunk_budget}",
+        memory=f"{memory_tokens_used}/{budget.memory_tokens}",
+        conversation=f"{conversation_tokens_used}/{budget.conversation_tokens}",
         total=f"{total_tokens}/{budget.max_total_tokens}",
     )
 
@@ -356,4 +411,6 @@ def assemble_context(
         relationship_tokens_used=relationship_tokens_used,
         chunk_tokens_used=chunk_tokens_used,
         total_tokens=total_tokens,
+        memory_tokens_used=memory_tokens_used,
+        conversation_tokens_used=conversation_tokens_used,
     )

--- a/src/pam/agent/context_assembly.py
+++ b/src/pam/agent/context_assembly.py
@@ -395,7 +395,10 @@ def assemble_context(
         conversation_context=truncated_conversation,
     )
 
-    total_tokens = entity_tokens_used + relationship_tokens_used + chunk_tokens_used + memory_tokens_used + conversation_tokens_used
+    total_tokens = (
+        entity_tokens_used + relationship_tokens_used + chunk_tokens_used
+        + memory_tokens_used + conversation_tokens_used
+    )
 
     logger.debug(
         "context_assembly_budget",

--- a/src/pam/api/main.py
+++ b/src/pam/api/main.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from pam.api.deps import get_db, get_es_client
 from pam.api.middleware import CorrelationIdMiddleware, RequestLoggingMiddleware
 from pam.api.rate_limit import limiter, rate_limit_exceeded_handler
-from pam.api.routes import admin, auth, chat, documents, graph, ingest, memory, search
+from pam.api.routes import admin, auth, chat, conversation, documents, graph, ingest, memory, search
 from pam.common.cache import CacheService
 from pam.common.config import settings
 from pam.common.logging import configure_logging
@@ -251,6 +251,7 @@ def create_app() -> FastAPI:
     app.include_router(admin.router, prefix="/api", tags=["admin"])
     app.include_router(graph.router, prefix="/api", tags=["graph"])
     app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
+    app.include_router(conversation.router, prefix="/api/conversations", tags=["conversations"])
 
     # Override the memory service dependency
     from pam.api.routes.memory import get_memory_service as _get_memory_svc

--- a/src/pam/api/main.py
+++ b/src/pam/api/main.py
@@ -153,6 +153,50 @@ async def lifespan(app: FastAPI):
         app.state.memory_service = None
         logger.warning("memory_service_init_failed", exc_info=True)
 
+    # --- Conversation Service ---
+    try:
+        from pam.conversation.service import ConversationService
+
+        conversation_service = ConversationService(
+            session_factory=session_factory,
+        )
+        app.state.conversation_service = conversation_service
+        logger.info("conversation_service_initialized")
+
+        # --- Fact Extraction Pipeline (depends on memory + conversation) ---
+        if app.state.memory_service and settings.conversation_extraction_enabled:
+            from pam.conversation.extraction import FactExtractionPipeline
+
+            app.state.extraction_pipeline = FactExtractionPipeline(
+                memory_service=app.state.memory_service,
+                anthropic_api_key=settings.anthropic_api_key,
+                model=settings.conversation_extraction_model,
+            )
+            logger.info("extraction_pipeline_initialized")
+        else:
+            app.state.extraction_pipeline = None
+
+        # --- Conversation Summarizer ---
+        if app.state.memory_service:
+            from pam.conversation.summarizer import ConversationSummarizer
+
+            app.state.conversation_summarizer = ConversationSummarizer(
+                conversation_service=conversation_service,
+                memory_service=app.state.memory_service,
+                anthropic_api_key=settings.anthropic_api_key,
+                model=settings.conversation_extraction_model,
+                summary_threshold=settings.conversation_summary_threshold,
+            )
+            logger.info("conversation_summarizer_initialized")
+        else:
+            app.state.conversation_summarizer = None
+
+    except Exception:
+        app.state.conversation_service = None
+        app.state.extraction_pipeline = None
+        app.state.conversation_summarizer = None
+        logger.warning("conversation_service_init_failed", exc_info=True)
+
     # --- Graphiti / Neo4j ---
     graph_service = None
     try:
@@ -263,6 +307,17 @@ def create_app() -> FastAPI:
         return svc
 
     app.dependency_overrides[_get_memory_svc] = _memory_svc_override
+
+    # Override the conversation service dependency
+    from pam.api.routes.conversation import get_conversation_service as _get_conv_svc
+
+    def _conv_svc_override():
+        svc = getattr(app.state, "conversation_service", None)
+        if svc is None:
+            raise RuntimeError("ConversationService not initialized")
+        return svc
+
+    app.dependency_overrides[_get_conv_svc] = _conv_svc_override
 
     @app.get("/api/health")
     async def health(

--- a/src/pam/api/main.py
+++ b/src/pam/api/main.py
@@ -186,6 +186,7 @@ async def lifespan(app: FastAPI):
                 anthropic_api_key=settings.anthropic_api_key,
                 model=settings.conversation_extraction_model,
                 summary_threshold=settings.conversation_summary_threshold,
+                summary_token_limit=settings.conversation_summary_token_limit,
             )
             logger.info("conversation_summarizer_initialized")
         else:

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -74,8 +74,11 @@ async def _persist_exchange(
 
         await conv_service.add_message(conv_id, role="user", content=user_message)
         await conv_service.add_message(conv_id, role="assistant", content=assistant_response)
-        # Re-fetch to get the latest detail (including project_id).
-        persisted_detail = existing or await conv_service.get(conv_id)
+        # Always re-fetch to get the latest detail (fresh message_count +
+        # project_id). Relying on the pre-add `existing` snapshot left
+        # message_count stale, so the summarizer's should_summarize() could
+        # miss the threshold on the exact turn it was crossed.
+        persisted_detail = await conv_service.get(conv_id)
 
     except Exception:
         logger.warning("chat_persist_error", conversation_id=conversation_id, exc_info=True)

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -91,8 +91,9 @@ async def _persist_exchange(
     summarizer = getattr(request.app.state, "conversation_summarizer", None)
     if summarizer is not None:
         try:
-            if await summarizer.should_summarize(conv_id):
-                await summarizer.summarize(conv_id)
+            conv_detail = await summarizer.should_summarize(conv_id)
+            if conv_detail is not None:
+                await summarizer.summarize(conv_id, detail=conv_detail)
         except Exception:
             logger.warning("chat_summarization_error", exc_info=True)
 
@@ -267,8 +268,8 @@ async def chat_stream(
             conversation_history=history,
             source_type=body.source_type,
         ):
-            if chunk.get("type") == "content":
-                full_response += chunk.get("text", "")
+            if chunk.get("type") == "token":
+                full_response += chunk.get("content", "")
             if chunk.get("type") == "done":
                 chunk["conversation_id"] = conversation_id
             yield f"data: {json.dumps(chunk)}\n\n"

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -47,17 +47,27 @@ async def _persist_exchange(
     if conv_service is None:
         return
 
-    try:
-        conv_id = uuid.UUID(conversation_id)
+    conv_id = _parse_uuid(conversation_id)
+    if conv_id is None:
+        logger.warning("chat_persist_invalid_uuid", conversation_id=conversation_id)
+        return
 
-        # Create conversation if it doesn't exist yet (first turn)
+    try:
+        # Create conversation if it doesn't exist yet (first turn).
+        # Use try/except to handle race conditions from concurrent requests.
         existing = await conv_service.get(conv_id)
         if existing is None:
-            await conv_service.create_with_id(
-                conversation_id=conv_id,
-                user_id=user_id,
-                title=user_message[:100],
-            )
+            try:
+                await conv_service.create_with_id(
+                    conversation_id=conv_id,
+                    user_id=user_id,
+                    title=user_message[:100],
+                )
+            except Exception:
+                # Race: another request already created it — re-fetch to confirm
+                existing = await conv_service.get(conv_id)
+                if existing is None:
+                    raise
 
         await conv_service.add_message(conv_id, role="user", content=user_message)
         await conv_service.add_message(conv_id, role="assistant", content=assistant_response)
@@ -81,7 +91,6 @@ async def _persist_exchange(
     summarizer = getattr(request.app.state, "conversation_summarizer", None)
     if summarizer is not None:
         try:
-            conv_id = uuid.UUID(conversation_id)
             if await summarizer.should_summarize(conv_id):
                 await summarizer.summarize(conv_id)
         except Exception:
@@ -124,7 +133,7 @@ class ChatDebugResponse(BaseModel):
 @router.post("/chat/debug", response_model=ChatDebugResponse)
 @limiter.limit(settings.rate_limit_chat)
 async def chat_debug(
-    request: Request,  # noqa: ARG001
+    request: Request,
     body: ChatRequest,
     agent: RetrievalAgent = Depends(get_agent),
     _user: User | None = Depends(get_current_user),
@@ -149,6 +158,12 @@ async def chat_debug(
     except Exception as e:
         logger.exception("chat_debug_error", message=body.message[:100])
         raise HTTPException(status_code=500, detail="An internal error occurred") from e
+
+    # Persist exchange inline (same as chat/chat_stream)
+    await _persist_exchange(
+        request, conversation_id, body.message, result.answer,
+        user_id=_user.id if _user else None,
+    )
 
     return ChatDebugResponse(
         response=result.answer,

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -21,6 +21,63 @@ logger = structlog.get_logger()
 router = APIRouter()
 
 
+async def _persist_exchange(
+    request: Request,
+    conversation_id: str,
+    user_message: str,
+    assistant_response: str,
+    user_id: uuid.UUID | None = None,
+) -> None:
+    """Persist conversation exchange and trigger fact extraction.
+
+    Called inline (awaited) before returning the response, so no
+    fire-and-forget / orphaned-task issues.
+    """
+    conv_service = getattr(request.app.state, "conversation_service", None)
+    if conv_service is None:
+        return
+
+    try:
+        conv_id = uuid.UUID(conversation_id)
+
+        # Create conversation if it doesn't exist yet (first turn)
+        existing = await conv_service.get(conv_id)
+        if existing is None:
+            await conv_service.create_with_id(
+                conversation_id=conv_id,
+                user_id=user_id,
+                title=user_message[:100],
+            )
+
+        await conv_service.add_message(conv_id, role="user", content=user_message)
+        await conv_service.add_message(conv_id, role="assistant", content=assistant_response)
+
+    except Exception:
+        logger.warning("chat_persist_error", conversation_id=conversation_id, exc_info=True)
+
+    # Trigger fact extraction
+    extraction = getattr(request.app.state, "extraction_pipeline", None)
+    if extraction is not None:
+        try:
+            await extraction.extract_from_exchange(
+                user_message=user_message,
+                assistant_response=assistant_response,
+                user_id=user_id,
+            )
+        except Exception:
+            logger.warning("chat_extraction_error", exc_info=True)
+
+    # Trigger summarization check
+    summarizer = getattr(request.app.state, "conversation_summarizer", None)
+    if summarizer is not None:
+        try:
+            conv_id = uuid.UUID(conversation_id)
+            if await summarizer.should_summarize(conv_id):
+                await summarizer.summarize(conv_id)
+        except Exception:
+            logger.warning("chat_summarization_error", exc_info=True)
+
+
 class ConversationMessage(BaseModel):
     role: Literal["user", "assistant"]
     content: str
@@ -100,7 +157,7 @@ async def chat_debug(
 @router.post("/chat", response_model=ChatResponse)
 @limiter.limit(settings.rate_limit_chat)
 async def chat(
-    request: Request,  # noqa: ARG001
+    request: Request,
     body: ChatRequest,
     agent: RetrievalAgent = Depends(get_agent),
     _user: User | None = Depends(get_current_user),
@@ -119,6 +176,12 @@ async def chat(
     except Exception as e:
         logger.exception("chat_error", message=body.message[:100])
         raise HTTPException(status_code=500, detail="An internal error occurred") from e
+
+    # Persist exchange inline
+    await _persist_exchange(
+        request, conversation_id, body.message, result.answer,
+        user_id=_user.id if _user else None,
+    )
 
     return ChatResponse(
         response=result.answer,
@@ -142,7 +205,7 @@ async def chat(
 @router.post("/chat/stream")
 @limiter.limit(settings.rate_limit_chat)
 async def chat_stream(
-    request: Request,  # noqa: ARG001
+    request: Request,
     body: ChatRequest,
     agent: RetrievalAgent = Depends(get_agent),
     _user: User | None = Depends(get_current_user),
@@ -155,14 +218,24 @@ async def chat_stream(
         history = [{"role": m.role, "content": m.content} for m in body.conversation_history]
 
     async def event_generator():
+        full_response = ""
         async for chunk in agent.answer_streaming(
             body.message,
             conversation_history=history,
             source_type=body.source_type,
         ):
+            if chunk.get("type") == "content":
+                full_response += chunk.get("text", "")
             if chunk.get("type") == "done":
                 chunk["conversation_id"] = conversation_id
             yield f"data: {json.dumps(chunk)}\n\n"
+
+        # Persist after streaming completes
+        if full_response:
+            await _persist_exchange(
+                request, conversation_id, body.message, full_response,
+                user_id=_user.id if _user else None,
+            )
 
     return StreamingResponse(
         event_generator(),

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -21,6 +21,16 @@ logger = structlog.get_logger()
 router = APIRouter()
 
 
+def _parse_uuid(value: str | None) -> uuid.UUID | None:
+    """Return a UUID if value is a valid UUID string, otherwise None."""
+    if not value:
+        return None
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        return None
+
+
 async def _persist_exchange(
     request: Request,
     conversation_id: str,
@@ -128,6 +138,12 @@ async def chat_debug(
     if body.source_type:
         kwargs["source_type"] = body.source_type
 
+    # Set per-request context for memory + conversation injection
+    agent._memory_service = getattr(request.app.state, "memory_service", None)
+    agent._conversation_service = getattr(request.app.state, "conversation_service", None)
+    agent._current_user_id = _user.id if _user else None
+    agent._current_conversation_id = _parse_uuid(conversation_id)
+
     try:
         result: AgentResponse = await agent.answer(body.message, **kwargs)
     except Exception as e:
@@ -171,6 +187,12 @@ async def chat(
     if body.source_type:
         kwargs["source_type"] = body.source_type
 
+    # Set per-request context for memory + conversation injection
+    agent._memory_service = getattr(request.app.state, "memory_service", None)
+    agent._conversation_service = getattr(request.app.state, "conversation_service", None)
+    agent._current_user_id = _user.id if _user else None
+    agent._current_conversation_id = _parse_uuid(conversation_id)
+
     try:
         result: AgentResponse = await agent.answer(body.message, **kwargs)
     except Exception as e:
@@ -212,6 +234,12 @@ async def chat_stream(
 ):
     """Stream a chat response as Server-Sent Events."""
     conversation_id = body.conversation_id or str(uuid.uuid4())
+
+    # Set per-request context for memory + conversation injection
+    agent._memory_service = getattr(request.app.state, "memory_service", None)
+    agent._conversation_service = getattr(request.app.state, "conversation_service", None)
+    agent._current_user_id = _user.id if _user else None
+    agent._current_conversation_id = _parse_uuid(conversation_id)
 
     history = None
     if body.conversation_history:

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -41,7 +41,8 @@ async def _persist_exchange(
     """Persist conversation exchange and trigger fact extraction.
 
     Called inline (awaited) before returning the response, so no
-    fire-and-forget / orphaned-task issues.
+    fire-and-forget / orphaned-task issues.  Extraction and summarization
+    only run when persistence succeeds to avoid orphaned memories.
     """
     conv_service = getattr(request.app.state, "conversation_service", None)
     if conv_service is None:
@@ -52,6 +53,8 @@ async def _persist_exchange(
         logger.warning("chat_persist_invalid_uuid", conversation_id=conversation_id)
         return
 
+    # Track the conversation detail so we can extract project_id later.
+    persisted_detail = None
     try:
         # Create conversation if it doesn't exist yet (first turn).
         # Use try/except to handle race conditions from concurrent requests.
@@ -71,9 +74,14 @@ async def _persist_exchange(
 
         await conv_service.add_message(conv_id, role="user", content=user_message)
         await conv_service.add_message(conv_id, role="assistant", content=assistant_response)
+        # Re-fetch to get the latest detail (including project_id).
+        persisted_detail = existing or await conv_service.get(conv_id)
 
     except Exception:
         logger.warning("chat_persist_error", conversation_id=conversation_id, exc_info=True)
+        return  # Skip extraction/summarization when persistence fails
+
+    project_id = getattr(persisted_detail, "project_id", None) if persisted_detail else None
 
     # Trigger fact extraction
     extraction = getattr(request.app.state, "extraction_pipeline", None)
@@ -83,6 +91,7 @@ async def _persist_exchange(
                 user_message=user_message,
                 assistant_response=assistant_response,
                 user_id=user_id,
+                project_id=project_id,
             )
         except Exception:
             logger.warning("chat_extraction_error", exc_info=True)
@@ -263,23 +272,24 @@ async def chat_stream(
 
     async def event_generator():
         full_response = ""
-        async for chunk in agent.answer_streaming(
-            body.message,
-            conversation_history=history,
-            source_type=body.source_type,
-        ):
-            if chunk.get("type") == "token":
-                full_response += chunk.get("content", "")
-            if chunk.get("type") == "done":
-                chunk["conversation_id"] = conversation_id
-            yield f"data: {json.dumps(chunk)}\n\n"
-
-        # Persist after streaming completes
-        if full_response:
-            await _persist_exchange(
-                request, conversation_id, body.message, full_response,
-                user_id=_user.id if _user else None,
-            )
+        try:
+            async for chunk in agent.answer_streaming(
+                body.message,
+                conversation_history=history,
+                source_type=body.source_type,
+            ):
+                if chunk.get("type") == "token":
+                    full_response += chunk.get("content", "")
+                if chunk.get("type") == "done":
+                    chunk["conversation_id"] = conversation_id
+                yield f"data: {json.dumps(chunk)}\n\n"
+        finally:
+            # Persist after streaming completes (or on client disconnect)
+            if full_response:
+                await _persist_exchange(
+                    request, conversation_id, body.message, full_response,
+                    user_id=_user.id if _user else None,
+                )
 
     return StreamingResponse(
         event_generator(),

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -43,29 +43,17 @@ async def create_conversation(
 ):
     """Create a new conversation."""
     owner = _require_user(user)
+    # When auth is disabled, require user_id in the request body
+    effective_user_id = owner.id if owner else body.user_id
     return await service.create(
-        user_id=owner.id if owner else body.user_id,
+        user_id=effective_user_id,
         project_id=body.project_id,
         title=body.title,
     )
 
 
-@router.get("/{conversation_id}", response_model=ConversationDetail)
-async def get_conversation(
-    conversation_id: uuid.UUID,
-    service=Depends(get_conversation_service),
-    user: User | None = Depends(get_current_user),
-):
-    """Get a conversation with all its messages."""
-    owner = _require_user(user)
-    result = await service.get(conversation_id)
-    if result is None:
-        raise HTTPException(status_code=404, detail="Conversation not found")
-    if owner and result.user_id and result.user_id != owner.id:
-        raise HTTPException(status_code=403, detail="Access denied")
-    return result
-
-
+# NOTE: /user/{user_id} must be registered BEFORE /{conversation_id}
+# to prevent FastAPI from matching "user" as a conversation_id UUID.
 @router.get("/user/{user_id}", response_model=list[ConversationResponse])
 async def list_user_conversations(
     user_id: uuid.UUID,
@@ -85,6 +73,22 @@ async def list_user_conversations(
         limit=limit,
         offset=offset,
     )
+
+
+@router.get("/{conversation_id}", response_model=ConversationDetail)
+async def get_conversation(
+    conversation_id: uuid.UUID,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """Get a conversation with all its messages."""
+    owner = _require_user(user)
+    result = await service.get(conversation_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if owner and result.user_id and result.user_id != owner.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    return result
 
 
 @router.post("/{conversation_id}/messages", response_model=ConvMessageResponse)

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -3,9 +3,10 @@
 import uuid
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from pam.api.auth import get_current_user
+from pam.api.rate_limit import limiter
 from pam.common.config import settings
 from pam.common.models import (
     ConversationCreate,
@@ -36,7 +37,9 @@ def _require_user(user: User | None) -> User | None:
 
 
 @router.post("", response_model=ConversationResponse)
+@limiter.limit(settings.rate_limit_conversation)
 async def create_conversation(
+    request: Request,
     body: ConversationCreate,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),
@@ -55,7 +58,9 @@ async def create_conversation(
 # NOTE: /user/{user_id} must be registered BEFORE /{conversation_id}
 # to prevent FastAPI from matching "user" as a conversation_id UUID.
 @router.get("/user/{user_id}", response_model=list[ConversationResponse])
+@limiter.limit(settings.rate_limit_conversation)
 async def list_user_conversations(
+    request: Request,
     user_id: uuid.UUID,
     project_id: uuid.UUID | None = None,
     limit: int = 50,
@@ -76,7 +81,9 @@ async def list_user_conversations(
 
 
 @router.get("/{conversation_id}", response_model=ConversationDetail)
+@limiter.limit(settings.rate_limit_conversation)
 async def get_conversation(
+    request: Request,
     conversation_id: uuid.UUID,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),
@@ -92,7 +99,9 @@ async def get_conversation(
 
 
 @router.post("/{conversation_id}/messages", response_model=ConvMessageResponse)
+@limiter.limit(settings.rate_limit_conversation)
 async def add_message(
+    request: Request,
     conversation_id: uuid.UUID,
     body: MessageCreate,
     service=Depends(get_conversation_service),
@@ -117,7 +126,9 @@ async def add_message(
 
 
 @router.delete("/{conversation_id}")
+@limiter.limit(settings.rate_limit_conversation)
 async def delete_conversation(
+    request: Request,
     conversation_id: uuid.UUID,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -57,10 +57,12 @@ async def get_conversation(
     user: User | None = Depends(get_current_user),
 ):
     """Get a conversation with all its messages."""
-    _require_user(user)
+    owner = _require_user(user)
     result = await service.get(conversation_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
+    if owner and result.user_id and result.user_id != owner.id:
+        raise HTTPException(status_code=403, detail="Access denied")
     return result
 
 
@@ -74,9 +76,11 @@ async def list_user_conversations(
     user: User | None = Depends(get_current_user),
 ):
     """List conversations for a user."""
-    _require_user(user)
+    owner = _require_user(user)
+    # When auth is enabled, only allow listing your own conversations
+    effective_user_id = owner.id if owner else user_id
     return await service.list_by_user(
-        user_id=user_id,
+        user_id=effective_user_id,
         project_id=project_id,
         limit=limit,
         offset=offset,
@@ -91,10 +95,12 @@ async def add_message(
     user: User | None = Depends(get_current_user),
 ):
     """Add a message to a conversation."""
-    _require_user(user)
+    owner = _require_user(user)
     existing = await service.get(conversation_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
+    if owner and existing.user_id and existing.user_id != owner.id:
+        raise HTTPException(status_code=403, detail="Access denied")
     try:
         return await service.add_message(
             conversation_id=conversation_id,
@@ -113,9 +119,11 @@ async def delete_conversation(
     user: User | None = Depends(get_current_user),
 ):
     """Delete a conversation and all its messages."""
-    _require_user(user)
+    owner = _require_user(user)
     existing = await service.get(conversation_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
+    if owner and existing.user_id and existing.user_id != owner.id:
+        raise HTTPException(status_code=403, detail="Access denied")
     await service.delete(conversation_id)
     return {"message": "Conversation deleted", "id": str(conversation_id)}

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -39,7 +39,7 @@ def _require_user(user: User | None) -> User | None:
 @router.post("", response_model=ConversationResponse)
 @limiter.limit(settings.rate_limit_conversation)
 async def create_conversation(
-    request: Request,
+    request: Request,  # noqa: ARG001
     body: ConversationCreate,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),
@@ -60,7 +60,7 @@ async def create_conversation(
 @router.get("/user/{user_id}", response_model=list[ConversationResponse])
 @limiter.limit(settings.rate_limit_conversation)
 async def list_user_conversations(
-    request: Request,
+    request: Request,  # noqa: ARG001
     user_id: uuid.UUID,
     project_id: uuid.UUID | None = None,
     limit: int = 50,
@@ -83,7 +83,7 @@ async def list_user_conversations(
 @router.get("/{conversation_id}", response_model=ConversationDetail)
 @limiter.limit(settings.rate_limit_conversation)
 async def get_conversation(
-    request: Request,
+    request: Request,  # noqa: ARG001
     conversation_id: uuid.UUID,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),
@@ -101,7 +101,7 @@ async def get_conversation(
 @router.post("/{conversation_id}/messages", response_model=ConvMessageResponse)
 @limiter.limit(settings.rate_limit_conversation)
 async def add_message(
-    request: Request,
+    request: Request,  # noqa: ARG001
     conversation_id: uuid.UUID,
     body: MessageCreate,
     service=Depends(get_conversation_service),
@@ -128,7 +128,7 @@ async def add_message(
 @router.delete("/{conversation_id}")
 @limiter.limit(settings.rate_limit_conversation)
 async def delete_conversation(
-    request: Request,
+    request: Request,  # noqa: ARG001
     conversation_id: uuid.UUID,
     service=Depends(get_conversation_service),
     user: User | None = Depends(get_current_user),

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -1,0 +1,121 @@
+"""Conversation endpoints — CRUD for conversations and messages."""
+
+import uuid
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+
+from pam.api.auth import get_current_user
+from pam.common.config import settings
+from pam.common.models import (
+    ConversationCreate,
+    ConversationDetail,
+    ConversationResponse,
+    ConvMessageResponse,
+    MessageCreate,
+    User,
+)
+
+logger = structlog.get_logger()
+
+router = APIRouter()
+
+
+def get_conversation_service():
+    """Dependency stub — overridden at app startup."""
+    raise RuntimeError("ConversationService not initialized")
+
+
+def _require_user(user: User | None) -> User | None:
+    """Raise 401 if auth is enabled but no user. Returns None if auth disabled."""
+    if not settings.auth_required:
+        return None
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
+
+
+@router.post("", response_model=ConversationResponse)
+async def create_conversation(
+    body: ConversationCreate,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """Create a new conversation."""
+    owner = _require_user(user)
+    return await service.create(
+        user_id=owner.id if owner else body.user_id,
+        project_id=body.project_id,
+        title=body.title,
+    )
+
+
+@router.get("/{conversation_id}", response_model=ConversationDetail)
+async def get_conversation(
+    conversation_id: uuid.UUID,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """Get a conversation with all its messages."""
+    _require_user(user)
+    result = await service.get(conversation_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return result
+
+
+@router.get("/user/{user_id}", response_model=list[ConversationResponse])
+async def list_user_conversations(
+    user_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """List conversations for a user."""
+    _require_user(user)
+    return await service.list_by_user(
+        user_id=user_id,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/{conversation_id}/messages", response_model=ConvMessageResponse)
+async def add_message(
+    conversation_id: uuid.UUID,
+    body: MessageCreate,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """Add a message to a conversation."""
+    _require_user(user)
+    existing = await service.get(conversation_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    try:
+        return await service.add_message(
+            conversation_id=conversation_id,
+            role=body.role,
+            content=body.content,
+            metadata=body.metadata,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@router.delete("/{conversation_id}")
+async def delete_conversation(
+    conversation_id: uuid.UUID,
+    service=Depends(get_conversation_service),
+    user: User | None = Depends(get_current_user),
+):
+    """Delete a conversation and all its messages."""
+    _require_user(user)
+    existing = await service.get(conversation_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    await service.delete(conversation_id)
+    return {"message": "Conversation deleted", "id": str(conversation_id)}

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -93,7 +93,9 @@ async def get_conversation(
     result = await service.get(conversation_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    if owner and result.user_id and result.user_id != owner.id:
+    # Deny access if auth is enabled and the conversation has a different owner
+    # (ownerless conversations are only accessible when auth is disabled)
+    if owner and (not result.user_id or result.user_id != owner.id):
         raise HTTPException(status_code=403, detail="Access denied")
     return result
 
@@ -112,17 +114,14 @@ async def add_message(
     existing = await service.get(conversation_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    if owner and existing.user_id and existing.user_id != owner.id:
+    if owner and (not existing.user_id or existing.user_id != owner.id):
         raise HTTPException(status_code=403, detail="Access denied")
-    try:
-        return await service.add_message(
-            conversation_id=conversation_id,
-            role=body.role,
-            content=body.content,
-            metadata=body.metadata,
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+    return await service.add_message(
+        conversation_id=conversation_id,
+        role=body.role,
+        content=body.content,
+        metadata=body.metadata,
+    )
 
 
 @router.delete("/{conversation_id}")
@@ -138,7 +137,7 @@ async def delete_conversation(
     existing = await service.get(conversation_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    if owner and existing.user_id and existing.user_id != owner.id:
+    if owner and (not existing.user_id or existing.user_id != owner.id):
         raise HTTPException(status_code=403, detail="Access denied")
     await service.delete(conversation_id)
     return {"message": "Conversation deleted", "id": str(conversation_id)}

--- a/src/pam/api/routes/conversation.py
+++ b/src/pam/api/routes/conversation.py
@@ -116,12 +116,20 @@ async def add_message(
         raise HTTPException(status_code=404, detail="Conversation not found")
     if owner and (not existing.user_id or existing.user_id != owner.id):
         raise HTTPException(status_code=403, detail="Access denied")
-    return await service.add_message(
-        conversation_id=conversation_id,
-        role=body.role,
-        content=body.content,
-        metadata=body.metadata,
-    )
+    try:
+        return await service.add_message(
+            conversation_id=conversation_id,
+            role=body.role,
+            content=body.content,
+            metadata=body.metadata,
+        )
+    except ValueError as exc:
+        # Service raises ValueError("Conversation {id} not found") when the
+        # conversation is deleted between the ownership check above and the
+        # insert — surface as 404 instead of a 500.
+        if "not found" in str(exc).lower():
+            raise HTTPException(status_code=404, detail="Conversation not found") from exc
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.delete("/{conversation_id}")

--- a/src/pam/common/config.py
+++ b/src/pam/common/config.py
@@ -102,6 +102,16 @@ class Settings(BaseSettings):
     memory_dedup_threshold: float = 0.9  # Cosine similarity threshold for dedup
     memory_merge_model: str = "claude-haiku-4-5-20251001"  # LLM for content merge
 
+    # Conversation Service
+    conversation_extraction_enabled: bool = True
+    conversation_extraction_model: str = "claude-haiku-4-5-20251001"
+    conversation_summary_threshold: int = 20  # messages before auto-summarization
+    conversation_summary_token_limit: int = 8000  # token budget for summary
+    conversation_context_max_tokens: int = 2000  # max tokens for conversation context in assembly
+
+    # Context Assembly — memory budget
+    context_memory_budget: int = 2000  # token budget for user memories in context
+
     # CLI connectors
     github_repos: list[dict] = []  # [{"repo":"owner/repo","branch":"main","paths":[],"extensions":[]}]
     use_cli_connectors: bool = False  # Use gws CLI instead of Google API connectors

--- a/src/pam/common/config.py
+++ b/src/pam/common/config.py
@@ -127,6 +127,7 @@ class Settings(BaseSettings):
     rate_limit_ingest: str = "5/minute"
     rate_limit_search: str = "30/minute"
     rate_limit_memory: str = "30/minute"
+    rate_limit_conversation: str = "30/minute"
 
     # App
     log_level: str = "INFO"

--- a/src/pam/common/config.py
+++ b/src/pam/common/config.py
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     # Context Assembly Token Budgets
     context_entity_budget: int = 4000
     context_relationship_budget: int = 6000
-    context_max_tokens: int = 12000
+    context_max_tokens: int = 16000
 
     # Mode Router
     mode_confidence_threshold: float = 0.7  # Below this, fall back to hybrid
@@ -162,10 +162,18 @@ class Settings(BaseSettings):
             raise ValueError(f"mode_confidence_threshold must be 0.0-1.0, got {self.mode_confidence_threshold}")
         if not 0.0 <= self.memory_dedup_threshold <= 1.0:
             raise ValueError(f"memory_dedup_threshold must be 0.0-1.0, got {self.memory_dedup_threshold}")
-        if self.context_entity_budget + self.context_relationship_budget > self.context_max_tokens:
+        total_budget = (
+            self.context_entity_budget
+            + self.context_relationship_budget
+            + self.context_memory_budget
+            + self.conversation_context_max_tokens
+        )
+        if total_budget > self.context_max_tokens:
             raise ValueError(
                 f"context budget overflow: entity ({self.context_entity_budget}) + "
-                f"relationship ({self.context_relationship_budget}) > "
+                f"relationship ({self.context_relationship_budget}) + "
+                f"memory ({self.context_memory_budget}) + "
+                f"conversation ({self.conversation_context_max_tokens}) = {total_budget} > "
                 f"max ({self.context_max_tokens})"
             )
         return self

--- a/src/pam/common/models.py
+++ b/src/pam/common/models.py
@@ -209,6 +209,48 @@ class Memory(Base):
     )
 
 
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), index=True
+    )
+    title: Mapped[str | None] = mapped_column(String(500))
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    last_active: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    messages: Mapped[list["Message"]] = relationship(
+        back_populates="conversation", cascade="all, delete-orphan", order_by="Message.created_at"
+    )
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="CASCADE"), index=True
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_: Mapped[dict] = mapped_column("metadata", JSONB, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    conversation: Mapped["Conversation"] = relationship(back_populates="messages")
+
+    __table_args__ = (
+        CheckConstraint(
+            "role IN ('user', 'assistant', 'system')",
+            name="ck_messages_role",
+        ),
+        {"comment": "Individual messages within a conversation"},
+    )
+
+
 # ── Pydantic Schemas ────────────────────────────────────────────────────
 
 

--- a/src/pam/common/models.py
+++ b/src/pam/common/models.py
@@ -468,3 +468,47 @@ class MemorySearchQuery(BaseModel):
 class MemorySearchResult(BaseModel):
     memory: MemoryResponse
     score: float
+
+
+# ── Conversation Schemas ──────────────────────────────────────────────
+
+
+class MessageCreate(BaseModel):
+    role: Literal["user", "assistant", "system"]
+    content: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class ConvMessageResponse(BaseModel):
+    """Response schema for a conversation message (not to be confused with the generic MessageResponse)."""
+
+    id: uuid.UUID
+    conversation_id: uuid.UUID
+    role: str
+    content: str
+    metadata: dict = Field(default_factory=dict)
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ConversationCreate(BaseModel):
+    user_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+    title: str | None = None
+
+
+class ConversationResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+    title: str | None = None
+    started_at: datetime
+    last_active: datetime
+    message_count: int = 0
+
+    model_config = {"from_attributes": True}
+
+
+class ConversationDetail(ConversationResponse):
+    messages: list[ConvMessageResponse] = []

--- a/src/pam/conversation/__init__.py
+++ b/src/pam/conversation/__init__.py
@@ -1,5 +1,6 @@
 """Conversation module — persistence, fact extraction, summarization."""
 
+from pam.conversation.extraction import FactExtractionPipeline
 from pam.conversation.service import ConversationService
 
-__all__ = ["ConversationService"]
+__all__ = ["ConversationService", "FactExtractionPipeline"]

--- a/src/pam/conversation/__init__.py
+++ b/src/pam/conversation/__init__.py
@@ -2,5 +2,6 @@
 
 from pam.conversation.extraction import FactExtractionPipeline
 from pam.conversation.service import ConversationService
+from pam.conversation.summarizer import ConversationSummarizer
 
-__all__ = ["ConversationService", "FactExtractionPipeline"]
+__all__ = ["ConversationService", "FactExtractionPipeline", "ConversationSummarizer"]

--- a/src/pam/conversation/__init__.py
+++ b/src/pam/conversation/__init__.py
@@ -4,4 +4,4 @@ from pam.conversation.extraction import FactExtractionPipeline
 from pam.conversation.service import ConversationService
 from pam.conversation.summarizer import ConversationSummarizer
 
-__all__ = ["ConversationService", "FactExtractionPipeline", "ConversationSummarizer"]
+__all__ = ["ConversationService", "ConversationSummarizer", "FactExtractionPipeline"]

--- a/src/pam/conversation/__init__.py
+++ b/src/pam/conversation/__init__.py
@@ -1,0 +1,5 @@
+"""Conversation module — persistence, fact extraction, summarization."""
+
+from pam.conversation.service import ConversationService
+
+__all__ = ["ConversationService"]

--- a/src/pam/conversation/extraction.py
+++ b/src/pam/conversation/extraction.py
@@ -1,0 +1,119 @@
+"""Fact extraction pipeline — extracts facts and preferences from conversation turns."""
+
+from __future__ import annotations
+
+import json
+import uuid as uuid_mod
+from typing import TYPE_CHECKING
+
+import structlog
+from anthropic import AsyncAnthropic
+
+if TYPE_CHECKING:
+    from pam.memory.service import MemoryService
+
+logger = structlog.get_logger()
+
+_EXTRACTION_PROMPT = """\
+Analyze this conversation exchange and extract any facts, preferences, or observations \
+that would be useful to remember for future conversations.
+
+User message:
+{user_message}
+
+Assistant response:
+{assistant_response}
+
+Return a JSON array of extracted items. Each item must have:
+- "type": one of "fact", "preference", "observation"
+- "content": a concise statement of the extracted information
+
+Rules:
+- Only extract genuinely useful, non-trivial information
+- Do NOT extract greetings, small talk, or transient questions
+- Do NOT extract information that is only relevant to the current exchange
+- Prefer the user's own statements for preferences
+- Return an empty array [] if nothing worth remembering
+
+Respond with ONLY the JSON array, no other text."""
+
+
+class FactExtractionPipeline:
+    """Extracts facts and preferences from conversation exchanges using an LLM."""
+
+    def __init__(
+        self,
+        memory_service: MemoryService,
+        anthropic_api_key: str,
+        model: str = "claude-haiku-4-5-20251001",
+    ) -> None:
+        self._memory_service = memory_service
+        self._client = AsyncAnthropic(api_key=anthropic_api_key)
+        self._model = model
+
+    async def extract_from_exchange(
+        self,
+        user_message: str,
+        assistant_response: str,
+        user_id: uuid_mod.UUID | None = None,
+        project_id: uuid_mod.UUID | None = None,
+    ) -> list[dict]:
+        """Extract facts/preferences from a user-assistant exchange.
+
+        Returns a list of dicts with 'type' and 'content' keys.
+        Extracted items are automatically stored via MemoryService.
+        """
+        try:
+            prompt = _EXTRACTION_PROMPT.format(
+                user_message=user_message,
+                assistant_response=assistant_response,
+            )
+
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}],
+            )
+
+            raw_text = response.content[0].text.strip()
+            extracted = json.loads(raw_text)
+
+            if not isinstance(extracted, list):
+                logger.warning("extraction_invalid_format", raw=raw_text[:200])
+                return []
+
+        except json.JSONDecodeError:
+            logger.warning("extraction_json_parse_error", exc_info=True)
+            return []
+        except Exception:
+            logger.warning("extraction_llm_error", exc_info=True)
+            return []
+
+        # Store each extracted item via MemoryService
+        stored: list[dict] = []
+        for item in extracted:
+            item_type = item.get("type", "fact")
+            content = item.get("content", "")
+            if not content:
+                continue
+            if item_type not in ("fact", "preference", "observation"):
+                item_type = "fact"
+
+            try:
+                await self._memory_service.store(
+                    content=content,
+                    memory_type=item_type,
+                    source="conversation",
+                    user_id=user_id,
+                    project_id=project_id,
+                )
+                stored.append(item)
+            except Exception:
+                logger.warning("extraction_store_error", content=content[:100], exc_info=True)
+
+        logger.info(
+            "facts_extracted",
+            count=len(stored),
+            user_id=str(user_id) if user_id else None,
+        )
+        return stored

--- a/src/pam/conversation/service.py
+++ b/src/pam/conversation/service.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import uuid as uuid_mod
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, ClassVar
 
 import structlog
 import tiktoken
@@ -91,7 +91,7 @@ def _conversation_to_detail(
 class ConversationService:
     """Manages conversation persistence and message storage."""
 
-    _VALID_ROLES = {"user", "assistant", "system"}
+    _VALID_ROLES: ClassVar[set[str]] = {"user", "assistant", "system"}
 
     def __init__(
         self,
@@ -107,7 +107,7 @@ class ConversationService:
     ) -> ConversationResponse:
         """Create a new conversation with a server-generated ID."""
         async with self._session_factory() as session:
-            now = datetime.now(tz=timezone.utc)
+            now = datetime.now(tz=UTC)
             conv = Conversation(
                 id=uuid_mod.uuid4(),
                 user_id=user_id,
@@ -137,7 +137,7 @@ class ConversationService:
         client matches the one stored in the database.
         """
         async with self._session_factory() as session:
-            now = datetime.now(tz=timezone.utc)
+            now = datetime.now(tz=UTC)
             conv = Conversation(
                 id=conversation_id,
                 user_id=user_id,
@@ -212,7 +212,7 @@ class ConversationService:
             if conv is None:
                 raise ValueError(f"Conversation {conversation_id} not found")
 
-            now = datetime.now(tz=timezone.utc)
+            now = datetime.now(tz=UTC)
             msg = Message(
                 id=uuid_mod.uuid4(),
                 conversation_id=conversation_id,

--- a/src/pam/conversation/service.py
+++ b/src/pam/conversation/service.py
@@ -1,0 +1,193 @@
+"""Conversation service — CRUD for conversations and messages."""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import structlog
+import tiktoken
+from sqlalchemy import func, select
+from sqlalchemy.orm import selectinload
+
+from pam.common.models import (
+    Conversation,
+    ConversationDetail,
+    ConversationResponse,
+    ConvMessageResponse,
+    Message,
+)
+
+# Module-level encoder cache (same pattern as context_assembly.py)
+_encoder: tiktoken.Encoding | None = None
+
+
+def _get_encoder() -> tiktoken.Encoding:
+    global _encoder
+    if _encoder is None:
+        _encoder = tiktoken.get_encoding("cl100k_base")
+    return _encoder
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+logger = structlog.get_logger()
+
+
+def _message_to_response(msg: Message) -> ConvMessageResponse:
+    """Convert a Message ORM instance to ConvMessageResponse."""
+    return ConvMessageResponse(
+        id=msg.id,
+        conversation_id=msg.conversation_id,
+        role=msg.role,
+        content=msg.content,
+        metadata=msg.metadata_ if isinstance(msg.metadata_, dict) else {},
+        created_at=msg.created_at,
+    )
+
+
+def _conversation_to_response(conv: Conversation, message_count: int = 0) -> ConversationResponse:
+    """Convert a Conversation ORM instance to ConversationResponse."""
+    return ConversationResponse(
+        id=conv.id,
+        user_id=conv.user_id,
+        project_id=conv.project_id,
+        title=conv.title,
+        started_at=conv.started_at,
+        last_active=conv.last_active,
+        message_count=message_count,
+    )
+
+
+def _conversation_to_detail(
+    conv: Conversation, message_limit: int | None = None
+) -> ConversationDetail:
+    """Convert a Conversation ORM instance to ConversationDetail with messages.
+
+    Parameters
+    ----------
+    message_limit:
+        If set, only include the N most recent messages.  The
+        ``message_count`` field still reflects the *total* message count.
+    """
+    all_messages = conv.messages  # already ordered by created_at via relationship
+    total = len(all_messages)
+    if message_limit is not None and message_limit < total:
+        all_messages = all_messages[-message_limit:]
+    messages = [_message_to_response(m) for m in all_messages]
+    return ConversationDetail(
+        id=conv.id,
+        user_id=conv.user_id,
+        project_id=conv.project_id,
+        title=conv.title,
+        started_at=conv.started_at,
+        last_active=conv.last_active,
+        message_count=total,
+        messages=messages,
+    )
+
+
+class ConversationService:
+    """Manages conversation persistence and message storage."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        self._session_factory = session_factory
+
+    async def create(
+        self,
+        user_id: uuid_mod.UUID | None = None,
+        project_id: uuid_mod.UUID | None = None,
+        title: str | None = None,
+    ) -> ConversationResponse:
+        """Create a new conversation with a server-generated ID."""
+        async with self._session_factory() as session:
+            now = datetime.now(tz=timezone.utc)
+            conv = Conversation(
+                id=uuid_mod.uuid4(),
+                user_id=user_id,
+                project_id=project_id,
+                title=title,
+                started_at=now,
+                last_active=now,
+            )
+            session.add(conv)
+            await session.flush()
+
+            result = _conversation_to_response(conv, message_count=0)
+            await session.commit()
+            logger.info("conversation_created", conversation_id=str(conv.id))
+            return result
+
+    async def create_with_id(
+        self,
+        conversation_id: uuid_mod.UUID,
+        user_id: uuid_mod.UUID | None = None,
+        project_id: uuid_mod.UUID | None = None,
+        title: str | None = None,
+    ) -> ConversationResponse:
+        """Create a new conversation with a client-supplied ID.
+
+        Used by the chat endpoint so the conversation_id returned to the
+        client matches the one stored in the database.
+        """
+        async with self._session_factory() as session:
+            now = datetime.now(tz=timezone.utc)
+            conv = Conversation(
+                id=conversation_id,
+                user_id=user_id,
+                project_id=project_id,
+                title=title,
+                started_at=now,
+                last_active=now,
+            )
+            session.add(conv)
+            await session.flush()
+
+            result = _conversation_to_response(conv, message_count=0)
+            await session.commit()
+            logger.info("conversation_created", conversation_id=str(conv.id))
+            return result
+
+    async def get(
+        self,
+        conversation_id: uuid_mod.UUID,
+        message_limit: int | None = None,
+    ) -> ConversationDetail | None:
+        """Get a conversation with its messages.
+
+        Parameters
+        ----------
+        conversation_id:
+            The conversation to retrieve.
+        message_limit:
+            If set, only return the N most recent messages (useful for large
+            conversations before summarization kicks in).  None = all messages.
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                select(Conversation)
+                .options(selectinload(Conversation.messages))
+                .where(Conversation.id == conversation_id)
+            )
+            result = await session.execute(stmt)
+            conv = result.scalar_one_or_none()
+            if conv is None:
+                return None
+            return _conversation_to_detail(conv, message_limit=message_limit)
+
+    async def delete(self, conversation_id: uuid_mod.UUID) -> bool:
+        """Delete a conversation and all its messages (cascade)."""
+        async with self._session_factory() as session:
+            stmt = select(Conversation).where(Conversation.id == conversation_id)
+            result = await session.execute(stmt)
+            conv = result.scalar_one_or_none()
+            if conv is None:
+                return False
+            await session.delete(conv)
+            await session.commit()
+            logger.info("conversation_deleted", conversation_id=str(conversation_id))
+            return True

--- a/src/pam/conversation/service.py
+++ b/src/pam/conversation/service.py
@@ -91,6 +91,8 @@ def _conversation_to_detail(
 class ConversationService:
     """Manages conversation persistence and message storage."""
 
+    _VALID_ROLES = {"user", "assistant", "system"}
+
     def __init__(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -191,3 +193,109 @@ class ConversationService:
             await session.commit()
             logger.info("conversation_deleted", conversation_id=str(conversation_id))
             return True
+
+    async def add_message(
+        self,
+        conversation_id: uuid_mod.UUID,
+        role: str,
+        content: str,
+        metadata: dict | None = None,
+    ) -> ConvMessageResponse:
+        """Add a message to an existing conversation."""
+        if role not in self._VALID_ROLES:
+            raise ValueError(f"Invalid role '{role}'. Must be one of: {self._VALID_ROLES}")
+
+        async with self._session_factory() as session:
+            stmt = select(Conversation).where(Conversation.id == conversation_id)
+            result = await session.execute(stmt)
+            conv = result.scalar_one_or_none()
+            if conv is None:
+                raise ValueError(f"Conversation {conversation_id} not found")
+
+            now = datetime.now(tz=timezone.utc)
+            msg = Message(
+                id=uuid_mod.uuid4(),
+                conversation_id=conversation_id,
+                role=role,
+                content=content,
+                metadata_=metadata or {},
+                created_at=now,
+            )
+            session.add(msg)
+            conv.last_active = now
+            await session.flush()
+
+            response = _message_to_response(msg)
+            await session.commit()
+            return response
+
+    async def list_by_user(
+        self,
+        user_id: uuid_mod.UUID,
+        project_id: uuid_mod.UUID | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[ConversationResponse]:
+        """List conversations for a user, ordered by last_active desc."""
+        async with self._session_factory() as session:
+            count_subq = (
+                select(
+                    Message.conversation_id,
+                    func.count(Message.id).label("message_count"),
+                )
+                .group_by(Message.conversation_id)
+                .subquery()
+            )
+
+            stmt = (
+                select(Conversation, func.coalesce(count_subq.c.message_count, 0).label("message_count"))
+                .outerjoin(count_subq, Conversation.id == count_subq.c.conversation_id)
+                .where(Conversation.user_id == user_id)
+            )
+            if project_id is not None:
+                stmt = stmt.where(Conversation.project_id == project_id)
+            stmt = stmt.order_by(Conversation.last_active.desc()).limit(limit).offset(offset)
+
+            result = await session.execute(stmt)
+            rows = result.all()
+            return [
+                _conversation_to_response(row.Conversation, message_count=row.message_count)
+                for row in rows
+            ]
+
+    async def get_recent_context(
+        self,
+        conversation_id: uuid_mod.UUID,
+        max_tokens: int = 2000,
+    ) -> str:
+        """Get recent conversation messages as formatted text within a token budget.
+
+        Returns messages from most recent backwards, formatted as 'role: content'.
+        Uses tiktoken directly to avoid coupling to the agent module.
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                select(Conversation)
+                .options(selectinload(Conversation.messages))
+                .where(Conversation.id == conversation_id)
+            )
+            result = await session.execute(stmt)
+            conv = result.scalar_one_or_none()
+            if conv is None:
+                return ""
+
+            # Walk messages from newest to oldest, accumulating within budget
+            messages = list(reversed(conv.messages))
+            selected: list[str] = []
+            tokens_used = 0
+            for msg in messages:
+                line = f"{msg.role}: {msg.content}"
+                line_tokens = len(_get_encoder().encode(line))
+                if tokens_used + line_tokens > max_tokens:
+                    break
+                selected.append(line)
+                tokens_used += line_tokens
+
+            # Reverse back to chronological order
+            selected.reverse()
+            return "\n".join(selected)

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -1,0 +1,97 @@
+"""Conversation summarizer — compresses long conversations into summary memories."""
+
+from __future__ import annotations
+
+import uuid as uuid_mod
+from typing import TYPE_CHECKING
+
+import structlog
+from anthropic import AsyncAnthropic
+
+if TYPE_CHECKING:
+    from pam.conversation.service import ConversationService
+    from pam.memory.service import MemoryService
+
+logger = structlog.get_logger()
+
+_SUMMARY_PROMPT = """\
+Summarize this conversation into a concise paragraph that captures the key topics discussed, \
+decisions made, facts learned, and any action items. Focus on information that would be \
+useful context for future conversations.
+
+Conversation:
+{conversation_text}
+
+Write a concise summary (2-4 sentences). Include specific details like names, numbers, \
+and decisions — not vague descriptions."""
+
+
+class ConversationSummarizer:
+    """Compresses long conversations into summary memories."""
+
+    def __init__(
+        self,
+        conversation_service: ConversationService,
+        memory_service: MemoryService,
+        anthropic_api_key: str,
+        model: str = "claude-haiku-4-5-20251001",
+        summary_threshold: int = 20,
+    ) -> None:
+        self._conversation_service = conversation_service
+        self._memory_service = memory_service
+        self._client = AsyncAnthropic(api_key=anthropic_api_key)
+        self._model = model
+        self._summary_threshold = summary_threshold
+
+    async def should_summarize(self, conversation_id: uuid_mod.UUID) -> bool:
+        """Check if a conversation exceeds the summary threshold."""
+        detail = await self._conversation_service.get(conversation_id)
+        if detail is None:
+            return False
+        return detail.message_count >= self._summary_threshold
+
+    async def summarize(self, conversation_id: uuid_mod.UUID) -> str:
+        """Generate a summary of the conversation and store as a memory.
+
+        Returns the summary text, or empty string on failure.
+        """
+        detail = await self._conversation_service.get(conversation_id)
+        if detail is None:
+            return ""
+
+        # Build conversation text
+        lines = [f"{m.role}: {m.content}" for m in detail.messages]
+        conversation_text = "\n".join(lines)
+
+        try:
+            prompt = _SUMMARY_PROMPT.format(conversation_text=conversation_text)
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=512,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            summary = response.content[0].text.strip()
+        except Exception:
+            logger.warning("summarization_llm_error", conversation_id=str(conversation_id), exc_info=True)
+            return ""
+
+        # Store as conversation_summary memory
+        try:
+            await self._memory_service.store(
+                content=summary,
+                memory_type="conversation_summary",
+                source="conversation",
+                metadata={"conversation_id": str(conversation_id)},
+                user_id=detail.user_id,
+                project_id=detail.project_id,
+            )
+        except Exception:
+            logger.warning("summarization_store_error", exc_info=True)
+            return ""
+
+        logger.info(
+            "conversation_summarized",
+            conversation_id=str(conversation_id),
+            summary_length=len(summary),
+        )
+        return summary

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -55,17 +55,17 @@ class ConversationSummarizer:
         self._summary_threshold = summary_threshold
         self._summary_token_limit = summary_token_limit
 
-    async def should_summarize(self, conversation_id: uuid_mod.UUID) -> bool:
+    async def should_summarize(self, conversation_id: uuid_mod.UUID):
         """Check if a conversation exceeds the summary threshold.
 
-        Returns False if a summary already exists for this conversation
-        (to avoid re-summarizing on every subsequent message).
+        Returns the ConversationDetail if summarization is needed, or None
+        if it is not (to avoid re-summarizing on every subsequent message).
         """
         detail = await self._conversation_service.get(conversation_id)
         if detail is None:
-            return False
+            return None
         if detail.message_count < self._summary_threshold:
-            return False
+            return None
         # Check if we already have a summary for this conversation
         existing = await self._memory_service.search(
             query=f"conversation summary {conversation_id}",
@@ -73,17 +73,18 @@ class ConversationSummarizer:
             top_k=1,
         )
         for r in existing:
-            meta = getattr(r.memory, "metadata_", None) or {}
+            meta = r.memory.metadata or {}
             if meta.get("conversation_id") == str(conversation_id):
-                return False
-        return True
+                return None
+        return detail
 
-    async def summarize(self, conversation_id: uuid_mod.UUID) -> str:
+    async def summarize(self, conversation_id: uuid_mod.UUID, detail=None) -> str:
         """Generate a summary of the conversation and store as a memory.
 
         Returns the summary text, or empty string on failure.
         """
-        detail = await self._conversation_service.get(conversation_id)
+        if detail is None:
+            detail = await self._conversation_service.get(conversation_id)
         if detail is None:
             return ""
 

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -56,11 +56,27 @@ class ConversationSummarizer:
         self._summary_token_limit = summary_token_limit
 
     async def should_summarize(self, conversation_id: uuid_mod.UUID) -> bool:
-        """Check if a conversation exceeds the summary threshold."""
+        """Check if a conversation exceeds the summary threshold.
+
+        Returns False if a summary already exists for this conversation
+        (to avoid re-summarizing on every subsequent message).
+        """
         detail = await self._conversation_service.get(conversation_id)
         if detail is None:
             return False
-        return detail.message_count >= self._summary_threshold
+        if detail.message_count < self._summary_threshold:
+            return False
+        # Check if we already have a summary for this conversation
+        existing = await self._memory_service.search(
+            query=f"conversation summary {conversation_id}",
+            type_filter="conversation_summary",
+            top_k=1,
+        )
+        for r in existing:
+            meta = getattr(r.memory, "metadata_", None) or {}
+            if meta.get("conversation_id") == str(conversation_id):
+                return False
+        return True
 
     async def summarize(self, conversation_id: uuid_mod.UUID) -> str:
         """Generate a summary of the conversation and store as a memory.

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -6,6 +6,7 @@ import uuid as uuid_mod
 from typing import TYPE_CHECKING
 
 import structlog
+import tiktoken
 from anthropic import AsyncAnthropic
 
 if TYPE_CHECKING:
@@ -13,6 +14,15 @@ if TYPE_CHECKING:
     from pam.memory.service import MemoryService
 
 logger = structlog.get_logger()
+
+_encoder: tiktoken.Encoding | None = None
+
+
+def _get_encoder() -> tiktoken.Encoding:
+    global _encoder
+    if _encoder is None:
+        _encoder = tiktoken.get_encoding("cl100k_base")
+    return _encoder
 
 _SUMMARY_PROMPT = """\
 Summarize this conversation into a concise paragraph that captures the key topics discussed, \
@@ -36,12 +46,14 @@ class ConversationSummarizer:
         anthropic_api_key: str,
         model: str = "claude-haiku-4-5-20251001",
         summary_threshold: int = 20,
+        summary_token_limit: int = 8000,
     ) -> None:
         self._conversation_service = conversation_service
         self._memory_service = memory_service
         self._client = AsyncAnthropic(api_key=anthropic_api_key)
         self._model = model
         self._summary_threshold = summary_threshold
+        self._summary_token_limit = summary_token_limit
 
     async def should_summarize(self, conversation_id: uuid_mod.UUID) -> bool:
         """Check if a conversation exceeds the summary threshold."""
@@ -59,9 +71,14 @@ class ConversationSummarizer:
         if detail is None:
             return ""
 
-        # Build conversation text
+        # Build conversation text, truncated to token budget
         lines = [f"{m.role}: {m.content}" for m in detail.messages]
         conversation_text = "\n".join(lines)
+        encoder = _get_encoder()
+        tokens = encoder.encode(conversation_text)
+        if len(tokens) > self._summary_token_limit:
+            conversation_text = encoder.decode(tokens[-self._summary_token_limit :])
+            conversation_text = "[...earlier messages truncated...]\n" + conversation_text
 
         try:
             prompt = _SUMMARY_PROMPT.format(conversation_text=conversation_text)

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -55,7 +55,9 @@ class ConversationSummarizer:
         self._summary_threshold = summary_threshold
         self._summary_token_limit = summary_token_limit
 
-    async def should_summarize(self, conversation_id: uuid_mod.UUID):
+    async def should_summarize(
+        self, conversation_id: uuid_mod.UUID,
+    ) -> object | None:
         """Check if a conversation exceeds the summary threshold.
 
         Returns the ConversationDetail if summarization is needed, or None
@@ -66,11 +68,13 @@ class ConversationSummarizer:
             return None
         if detail.message_count < self._summary_threshold:
             return None
-        # Check if we already have a summary for this conversation
+        # Check if we already have a summary for this conversation.
+        # Use a targeted search and verify conversation_id in metadata to
+        # avoid false negatives from semantic ranking instability.
         existing = await self._memory_service.search(
             query=f"conversation summary {conversation_id}",
             type_filter="conversation_summary",
-            top_k=1,
+            top_k=5,
         )
         for r in existing:
             meta = r.memory.metadata or {}

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -68,18 +68,19 @@ class ConversationSummarizer:
             return None
         if detail.message_count < self._summary_threshold:
             return None
-        # Check if we already have a summary for this conversation.
-        # Use a targeted search and verify conversation_id in metadata to
-        # avoid false negatives from semantic ranking instability.
-        existing = await self._memory_service.search(
-            query=f"conversation summary {conversation_id}",
-            type_filter="conversation_summary",
-            top_k=5,
+        # Check if we already have a summary for this conversation. Use a
+        # direct JSONB metadata lookup rather than semantic search: the target
+        # summary can rank below top-k under load, and a missed dedup creates
+        # duplicate conversation_summary memories on every subsequent message.
+        existing = await self._memory_service.find_by_metadata(
+            memory_type="conversation_summary",
+            metadata_key="conversation_id",
+            metadata_value=str(conversation_id),
+            user_id=detail.user_id,
+            limit=1,
         )
-        for r in existing:
-            meta = r.memory.metadata or {}
-            if meta.get("conversation_id") == str(conversation_id):
-                return None
+        if existing:
+            return None
         return detail
 
     async def summarize(self, conversation_id: uuid_mod.UUID, detail=None) -> str:

--- a/src/pam/ingestion/task_manager.py
+++ b/src/pam/ingestion/task_manager.py
@@ -161,7 +161,7 @@ async def _run_pipeline(
                     await status_session.commit()
 
                 # Run the pipeline for each connector with a separate DB session
-                for (source_type, connector), docs in zip(connectors, prefetched_docs):
+                for (source_type, connector), docs in zip(connectors, prefetched_docs, strict=True):
                     async with session_factory() as pipeline_session:
                         parser = DoclingParser()
                         es_store = ElasticsearchStore(

--- a/src/pam/mcp/server.py
+++ b/src/pam/mcp/server.py
@@ -47,6 +47,7 @@ def create_mcp_server() -> FastMCP:
     _register_graph_tools(mcp)
     _register_utility_tools(mcp)
     _register_memory_tools(mcp)
+    _register_conversation_tools(mcp)
     _register_resources(mcp)
     return mcp
 
@@ -745,6 +746,90 @@ async def _pam_forget(memory_id: str, user_id: str) -> str:
     return json.dumps(
         {"deleted": False, "memory_id": memory_id, "error": "Memory not found"}
     )
+
+
+def _register_conversation_tools(mcp: FastMCP) -> None:
+    """Register conversation MCP tools."""
+
+    @mcp.tool()
+    async def pam_save_conversation(
+        messages: list[dict],
+        title: str | None = None,
+        user_id: str | None = None,
+        project_id: str | None = None,
+    ) -> str:
+        """Save a conversation (list of messages) to PAM.
+
+        Each message must have 'role' and 'content' keys.
+        Returns the conversation_id and number of messages saved.
+        """
+        return await _pam_save_conversation(
+            messages=messages, title=title,
+            user_id=user_id, project_id=project_id,
+        )
+
+    @mcp.tool()
+    async def pam_get_conversation_context(
+        conversation_id: str,
+        max_tokens: int = 2000,
+    ) -> str:
+        """Get recent conversation context formatted for LLM consumption.
+
+        Returns the conversation as 'role: content' lines, truncated to
+        max_tokens from the most recent messages backwards.
+        """
+        return await _pam_get_conversation_context(
+            conversation_id=conversation_id,
+            max_tokens=max_tokens,
+        )
+
+
+async def _pam_save_conversation(
+    messages: list[dict],
+    title: str | None = None,
+    user_id: str | None = None,
+    project_id: str | None = None,
+) -> str:
+    """Save a conversation to PAM."""
+    import uuid as uuid_mod
+
+    svc = get_services().conversation_service
+    if svc is None:
+        return json.dumps({"error": "ConversationService not available"})
+
+    uid = uuid_mod.UUID(user_id) if user_id else None
+    pid = uuid_mod.UUID(project_id) if project_id else None
+
+    conv = await svc.create(user_id=uid, project_id=pid, title=title)
+
+    for msg in messages:
+        await svc.add_message(
+            conversation_id=conv.id,
+            role=msg["role"],
+            content=msg["content"],
+            metadata=msg.get("metadata", {}),
+        )
+
+    return json.dumps({
+        "conversation_id": str(conv.id),
+        "messages_saved": len(messages),
+        "title": conv.title,
+    })
+
+
+async def _pam_get_conversation_context(
+    conversation_id: str,
+    max_tokens: int = 2000,
+) -> str:
+    """Get recent conversation context."""
+    import uuid as uuid_mod
+
+    svc = get_services().conversation_service
+    if svc is None:
+        return json.dumps({"error": "ConversationService not available"})
+
+    conv_id = uuid_mod.UUID(conversation_id)
+    return await svc.get_recent_context(conv_id, max_tokens=max_tokens)
 
 
 def _register_resources(mcp: FastMCP) -> None:

--- a/src/pam/mcp/server.py
+++ b/src/pam/mcp/server.py
@@ -797,8 +797,16 @@ async def _pam_save_conversation(
     if svc is None:
         return json.dumps({"error": "ConversationService not available"})
 
-    uid = uuid_mod.UUID(user_id) if user_id else None
-    pid = uuid_mod.UUID(project_id) if project_id else None
+    try:
+        uid = uuid_mod.UUID(user_id) if user_id else None
+        pid = uuid_mod.UUID(project_id) if project_id else None
+    except ValueError:
+        return json.dumps({"error": f"Invalid user_id or project_id: {user_id}, {project_id}"})
+
+    # Validate message structure before creating the conversation
+    for i, msg in enumerate(messages):
+        if "role" not in msg or "content" not in msg:
+            return json.dumps({"error": f"Message at index {i} missing required 'role' or 'content' key"})
 
     conv = await svc.create(user_id=uid, project_id=pid, title=title)
 
@@ -828,7 +836,11 @@ async def _pam_get_conversation_context(
     if svc is None:
         return json.dumps({"error": "ConversationService not available"})
 
-    conv_id = uuid_mod.UUID(conversation_id)
+    try:
+        conv_id = uuid_mod.UUID(conversation_id)
+    except ValueError:
+        return json.dumps({"error": f"Invalid conversation_id: {conversation_id}"})
+
     return await svc.get_recent_context(conv_id, max_tokens=max_tokens)
 
 

--- a/src/pam/mcp/server.py
+++ b/src/pam/mcp/server.py
@@ -803,20 +803,31 @@ async def _pam_save_conversation(
     except ValueError:
         return json.dumps({"error": f"Invalid user_id or project_id: {user_id}, {project_id}"})
 
-    # Validate message structure before creating the conversation
+    # Validate message structure and role values before creating the conversation
+    valid_roles = {"user", "assistant", "system"}
     for i, msg in enumerate(messages):
         if "role" not in msg or "content" not in msg:
             return json.dumps({"error": f"Message at index {i} missing required 'role' or 'content' key"})
+        if msg["role"] not in valid_roles:
+            return json.dumps({
+                "error": f"Message at index {i} has invalid role '{msg['role']}'. "
+                f"Must be one of: {sorted(valid_roles)}",
+            })
 
     conv = await svc.create(user_id=uid, project_id=pid, title=title)
 
-    for msg in messages:
-        await svc.add_message(
-            conversation_id=conv.id,
-            role=msg["role"],
-            content=msg["content"],
-            metadata=msg.get("metadata", {}),
-        )
+    try:
+        for msg in messages:
+            await svc.add_message(
+                conversation_id=conv.id,
+                role=msg["role"],
+                content=msg["content"],
+                metadata=msg.get("metadata", {}),
+            )
+    except Exception:
+        # Clean up the orphaned conversation record on failure
+        await svc.delete(conv.id)
+        raise
 
     return json.dumps({
         "conversation_id": str(conv.id),
@@ -841,7 +852,8 @@ async def _pam_get_conversation_context(
     except ValueError:
         return json.dumps({"error": f"Invalid conversation_id: {conversation_id}"})
 
-    return await svc.get_recent_context(conv_id, max_tokens=max_tokens)
+    context = await svc.get_recent_context(conv_id, max_tokens=max_tokens)
+    return json.dumps({"conversation_id": conversation_id, "context": context})
 
 
 def _register_resources(mcp: FastMCP) -> None:

--- a/src/pam/mcp/server.py
+++ b/src/pam/mcp/server.py
@@ -824,10 +824,19 @@ async def _pam_save_conversation(
                 content=msg["content"],
                 metadata=msg.get("metadata", {}),
             )
-    except Exception:
-        # Clean up the orphaned conversation record on failure
-        await svc.delete(conv.id)
-        raise
+    except Exception as exc:
+        # Clean up the orphaned conversation record on failure, then return a
+        # JSON error payload. MCP tools must return a string — never raise —
+        # so the client receives a structured error instead of a transport crash.
+        try:
+            await svc.delete(conv.id)
+        except Exception:
+            logger.warning(
+                "pam_save_conversation_orphan_cleanup_failed",
+                conversation_id=str(conv.id),
+                exc_info=True,
+            )
+        return json.dumps({"error": f"Failed to save conversation: {exc}"})
 
     return json.dumps({
         "conversation_id": str(conv.id),

--- a/src/pam/mcp/services.py
+++ b/src/pam/mcp/services.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from pam.graph.service import GraphitiService
     from pam.ingestion.embedders.base import BaseEmbedder
     from pam.ingestion.stores.entity_relationship_store import EntityRelationshipVDBStore
+    from pam.conversation.service import ConversationService
     from pam.memory.service import MemoryService
     from pam.retrieval.search_protocol import SearchService
 
@@ -35,6 +36,7 @@ class PamServices:
     duckdb_service: DuckDBService | None
     cache_service: CacheService | None
     memory_service: MemoryService | None
+    conversation_service: ConversationService | None
 
 
 def from_app_state(app_state: object) -> PamServices:
@@ -49,4 +51,5 @@ def from_app_state(app_state: object) -> PamServices:
         duckdb_service=getattr(app_state, "duckdb_service", None),
         cache_service=getattr(app_state, "cache_service", None),
         memory_service=getattr(app_state, "memory_service", None),
+        conversation_service=getattr(app_state, "conversation_service", None),
     )

--- a/src/pam/mcp/services.py
+++ b/src/pam/mcp/services.py
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
 
     from pam.agent.duckdb_service import DuckDBService
     from pam.common.cache import CacheService
+    from pam.conversation.service import ConversationService
     from pam.graph.service import GraphitiService
     from pam.ingestion.embedders.base import BaseEmbedder
     from pam.ingestion.stores.entity_relationship_store import EntityRelationshipVDBStore
-    from pam.conversation.service import ConversationService
     from pam.memory.service import MemoryService
     from pam.retrieval.search_protocol import SearchService
 

--- a/src/pam/memory/service.py
+++ b/src/pam/memory/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid as uuid_mod
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
@@ -135,7 +135,7 @@ class MemoryService:
 
         # No duplicate — insert new memory
         memory_id = uuid_mod.uuid4()
-        now = datetime.now(tz=timezone.utc)
+        now = datetime.now(tz=UTC)
         memory = Memory(
             id=memory_id,
             user_id=user_id,
@@ -186,9 +186,9 @@ class MemoryService:
         existing_id: uuid_mod.UUID,
         existing_content: str,
         new_content: str,
-        new_embedding: list[float],
-        user_id: uuid_mod.UUID | None,
-        project_id: uuid_mod.UUID | None,
+        new_embedding: list[float],  # noqa: ARG002
+        user_id: uuid_mod.UUID | None,  # noqa: ARG002
+        project_id: uuid_mod.UUID | None,  # noqa: ARG002
         new_importance: float | None = None,
         new_source: str | None = None,
         new_metadata: dict | None = None,
@@ -216,7 +216,7 @@ class MemoryService:
                 raise RuntimeError("Dedup target not found")
 
             existing.content = merged_content
-            existing.updated_at = datetime.now(tz=timezone.utc)
+            existing.updated_at = datetime.now(tz=UTC)
             if new_importance is not None:
                 existing.importance = max(existing.importance, new_importance)
             if new_source is not None:
@@ -318,7 +318,7 @@ class MemoryService:
             if memory is None:
                 return None
             memory.access_count = (memory.access_count or 0) + 1
-            memory.last_accessed_at = datetime.now(tz=timezone.utc)
+            memory.last_accessed_at = datetime.now(tz=UTC)
             await session.flush()
             await session.commit()
             return _memory_to_response(memory)
@@ -405,7 +405,7 @@ class MemoryService:
             elif clear_expires_at:
                 memory.expires_at = None
 
-            memory.updated_at = datetime.now(tz=timezone.utc)
+            memory.updated_at = datetime.now(tz=UTC)
             await session.flush()
             await session.commit()
 

--- a/src/pam/memory/service.py
+++ b/src/pam/memory/service.py
@@ -336,6 +336,35 @@ class MemoryService:
                 return None
             return _memory_to_response(memory)
 
+    async def find_by_metadata(
+        self,
+        memory_type: str,
+        metadata_key: str,
+        metadata_value: str,
+        user_id: uuid_mod.UUID | None = None,
+        limit: int = 1,
+    ) -> list[MemoryResponse]:
+        """Find memories by exact JSONB metadata field match via SQL.
+
+        Used by callers that need reliable dedup lookups (e.g. conversation
+        summary dedup), where semantic search is unreliable because the target
+        memory may rank below the top-k under load.
+        """
+        from sqlalchemy import select
+
+        async with self._session_factory() as session:
+            stmt = (
+                select(Memory)
+                .where(Memory.type == memory_type)
+                .where(Memory.metadata_[metadata_key].astext == metadata_value)
+                .limit(limit)
+            )
+            if user_id is not None:
+                stmt = stmt.where(Memory.user_id == user_id)
+            result = await session.execute(stmt)
+            memories = result.scalars().all()
+            return [_memory_to_response(m) for m in memories]
+
     async def list_by_user(
         self,
         user_id: uuid_mod.UUID,

--- a/tests/conversation/conftest.py
+++ b/tests/conversation/conftest.py
@@ -1,0 +1,37 @@
+"""Fixtures for conversation tests."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pam.conversation.service import ConversationService
+
+
+@pytest.fixture
+def mock_session():
+    """Mock async database session."""
+    session = AsyncMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.execute = AsyncMock()
+    session.delete = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def mock_session_factory(mock_session):
+    """Mock session factory returning mock_session as context manager."""
+    factory = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    factory.return_value = ctx
+    return factory
+
+
+@pytest.fixture
+def conversation_service(mock_session_factory):
+    """ConversationService with mocked session factory."""
+    return ConversationService(session_factory=mock_session_factory)

--- a/tests/conversation/conftest.py
+++ b/tests/conversation/conftest.py
@@ -1,7 +1,5 @@
 """Fixtures for conversation tests."""
 
-import uuid
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/conversation/test_extraction.py
+++ b/tests/conversation/test_extraction.py
@@ -1,7 +1,6 @@
 """Tests for FactExtractionPipeline."""
 
 import uuid
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/conversation/test_extraction.py
+++ b/tests/conversation/test_extraction.py
@@ -1,0 +1,130 @@
+"""Tests for FactExtractionPipeline."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pam.conversation.extraction import FactExtractionPipeline
+
+
+@pytest.fixture
+def mock_memory_service():
+    svc = AsyncMock()
+    svc.store = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def extraction_pipeline(mock_memory_service):
+    return FactExtractionPipeline(
+        memory_service=mock_memory_service,
+        anthropic_api_key="test-key",
+        model="claude-haiku-4-5-20251001",
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_facts_from_exchange(extraction_pipeline, mock_memory_service):
+    """extract_from_exchange() calls LLM and stores extracted facts."""
+    llm_response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = '[{"type": "fact", "content": "User prefers Python over JS"}]'
+    llm_response.content = [text_block]
+
+    with patch.object(extraction_pipeline, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(return_value=llm_response)
+
+        results = await extraction_pipeline.extract_from_exchange(
+            user_message="I always prefer Python for backend work",
+            assistant_response="Got it, I'll keep that in mind.",
+            user_id=uuid.uuid4(),
+            project_id=uuid.uuid4(),
+        )
+
+    assert len(results) == 1
+    assert results[0]["type"] == "fact"
+    mock_memory_service.store.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_extract_no_facts(extraction_pipeline, mock_memory_service):
+    """extract_from_exchange() returns empty list when no facts found."""
+    llm_response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = "[]"
+    llm_response.content = [text_block]
+
+    with patch.object(extraction_pipeline, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(return_value=llm_response)
+
+        results = await extraction_pipeline.extract_from_exchange(
+            user_message="What time is it?",
+            assistant_response="I don't have access to the current time.",
+        )
+
+    assert results == []
+    mock_memory_service.store.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extract_handles_llm_error(extraction_pipeline, mock_memory_service):
+    """extract_from_exchange() returns empty list on LLM failure."""
+    with patch.object(extraction_pipeline, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(side_effect=Exception("API error"))
+
+        results = await extraction_pipeline.extract_from_exchange(
+            user_message="Hello",
+            assistant_response="Hi there!",
+        )
+
+    assert results == []
+    mock_memory_service.store.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extract_handles_malformed_json(extraction_pipeline, mock_memory_service):
+    """extract_from_exchange() returns empty list on malformed LLM output."""
+    llm_response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = "not valid json"
+    llm_response.content = [text_block]
+
+    with patch.object(extraction_pipeline, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(return_value=llm_response)
+
+        results = await extraction_pipeline.extract_from_exchange(
+            user_message="Hello",
+            assistant_response="Hi!",
+        )
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_extract_multiple_facts(extraction_pipeline, mock_memory_service):
+    """extract_from_exchange() stores multiple extracted facts."""
+    llm_response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = (
+        '['
+        '{"type": "fact", "content": "Team uses PostgreSQL for analytics"},'
+        '{"type": "preference", "content": "User prefers concise answers"}'
+        ']'
+    )
+    llm_response.content = [text_block]
+
+    mock_memory_service.store.return_value = MagicMock()
+
+    with patch.object(extraction_pipeline, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(return_value=llm_response)
+
+        results = await extraction_pipeline.extract_from_exchange(
+            user_message="We use PostgreSQL. Please keep answers short.",
+            assistant_response="Understood. Noted your preferences.",
+            user_id=uuid.uuid4(),
+        )
+
+    assert len(results) == 2
+    assert mock_memory_service.store.await_count == 2

--- a/tests/conversation/test_routes.py
+++ b/tests/conversation/test_routes.py
@@ -1,7 +1,7 @@
 """Tests for conversation REST API routes."""
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -46,7 +46,7 @@ async def client(app):
 @pytest.mark.asyncio
 async def test_create_conversation(client, mock_conv_service):
     """POST /api/conversations creates a conversation."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     mock_conv_service.create.return_value = ConversationResponse(
         id=uuid.uuid4(),
         user_id=None,
@@ -66,7 +66,7 @@ async def test_create_conversation(client, mock_conv_service):
 async def test_get_conversation(client, mock_conv_service):
     """GET /api/conversations/{id} returns conversation detail."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     mock_conv_service.get.return_value = ConversationDetail(
         id=conv_id,
         title="Chat",
@@ -93,7 +93,7 @@ async def test_get_conversation_not_found(client, mock_conv_service):
 async def test_add_message(client, mock_conv_service):
     """POST /api/conversations/{id}/messages adds a message."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     # Need to mock get() for ownership check
     mock_conv_service.get.return_value = ConversationDetail(
         id=conv_id, title="Chat", started_at=now, last_active=now,
@@ -120,7 +120,7 @@ async def test_add_message(client, mock_conv_service):
 async def test_list_conversations(client, mock_conv_service):
     """GET /api/conversations/user/{user_id} lists conversations."""
     user_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     mock_conv_service.list_by_user.return_value = [
         ConversationResponse(
             id=uuid.uuid4(),
@@ -143,7 +143,7 @@ async def test_list_conversations(client, mock_conv_service):
 async def test_delete_conversation(client, mock_conv_service):
     """DELETE /api/conversations/{id} deletes conversation."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     # Mock get for ownership check
     mock_conv_service.get.return_value = ConversationDetail(
         id=conv_id, title="Chat", started_at=now, last_active=now,

--- a/tests/conversation/test_routes.py
+++ b/tests/conversation/test_routes.py
@@ -1,0 +1,164 @@
+"""Tests for conversation REST API routes."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from pam.api.deps import get_db
+from pam.api.main import create_app
+from pam.api.routes.conversation import get_conversation_service
+from pam.common.models import ConversationDetail, ConversationResponse, ConvMessageResponse
+
+
+@pytest.fixture
+def mock_conv_service():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_db_session():
+    return AsyncMock()
+
+
+@pytest.fixture
+def app(mock_conv_service, mock_db_session):
+    application = create_app()
+    application.dependency_overrides[get_conversation_service] = lambda: mock_conv_service
+    application.dependency_overrides[get_db] = lambda: mock_db_session
+    # Set app.state attributes used by middleware/health that read directly from app.state
+    application.state.session_factory = MagicMock()
+    application.state.cache_service = None
+    application.state.redis_client = None
+    application.state.graph_service = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_create_conversation(client, mock_conv_service):
+    """POST /api/conversations creates a conversation."""
+    now = datetime.now(tz=timezone.utc)
+    mock_conv_service.create.return_value = ConversationResponse(
+        id=uuid.uuid4(),
+        user_id=None,
+        project_id=None,
+        title="Test",
+        started_at=now,
+        last_active=now,
+        message_count=0,
+    )
+
+    resp = await client.post("/api/conversations", json={"title": "Test"})
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Test"
+
+
+@pytest.mark.asyncio
+async def test_get_conversation(client, mock_conv_service):
+    """GET /api/conversations/{id} returns conversation detail."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    mock_conv_service.get.return_value = ConversationDetail(
+        id=conv_id,
+        title="Chat",
+        started_at=now,
+        last_active=now,
+        message_count=0,
+        messages=[],
+    )
+
+    resp = await client.get(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Chat"
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_not_found(client, mock_conv_service):
+    """GET /api/conversations/{id} returns 404 when not found."""
+    mock_conv_service.get.return_value = None
+    resp = await client.get(f"/api/conversations/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_add_message(client, mock_conv_service):
+    """POST /api/conversations/{id}/messages adds a message."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    # Need to mock get() for ownership check
+    mock_conv_service.get.return_value = ConversationDetail(
+        id=conv_id, title="Chat", started_at=now, last_active=now,
+        message_count=1, messages=[],
+    )
+    mock_conv_service.add_message.return_value = ConvMessageResponse(
+        id=uuid.uuid4(),
+        conversation_id=conv_id,
+        role="user",
+        content="Hello",
+        metadata={},
+        created_at=now,
+    )
+
+    resp = await client.post(
+        f"/api/conversations/{conv_id}/messages",
+        json={"role": "user", "content": "Hello"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_list_conversations(client, mock_conv_service):
+    """GET /api/conversations/user/{user_id} lists conversations."""
+    user_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    mock_conv_service.list_by_user.return_value = [
+        ConversationResponse(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            title="Chat 1",
+            started_at=now,
+            last_active=now,
+            message_count=5,
+        ),
+    ]
+
+    resp = await client.get(f"/api/conversations/user/{user_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["message_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation(client, mock_conv_service):
+    """DELETE /api/conversations/{id} deletes conversation."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    # Mock get for ownership check
+    mock_conv_service.get.return_value = ConversationDetail(
+        id=conv_id, title="Chat", started_at=now, last_active=now,
+        message_count=0, messages=[],
+    )
+    mock_conv_service.delete.return_value = True
+
+    resp = await client.delete(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Conversation deleted"
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_not_found(client, mock_conv_service):
+    """DELETE /api/conversations/{id} returns 404 when not found."""
+    mock_conv_service.get.return_value = None
+    resp = await client.delete(f"/api/conversations/{uuid.uuid4()}")
+    assert resp.status_code == 404

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -1,0 +1,32 @@
+"""Tests for Conversation and Message models."""
+
+import uuid
+from datetime import datetime, timezone
+
+from pam.common.models import Conversation, Message
+
+
+def test_conversation_model_has_required_fields():
+    """Conversation ORM model has all expected columns."""
+    columns = {c.name for c in Conversation.__table__.columns}
+    expected = {
+        "id", "user_id", "project_id", "title",
+        "started_at", "last_active",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_message_model_has_required_fields():
+    """Message ORM model has all expected columns."""
+    columns = {c.name for c in Message.__table__.columns}
+    expected = {
+        "id", "conversation_id", "role", "content",
+        "metadata", "created_at",
+    }
+    assert expected.issubset(columns), f"Missing columns: {expected - columns}"
+
+
+def test_message_role_constraint():
+    """Message role column has a check constraint."""
+    constraints = [c.name for c in Message.__table__.constraints if hasattr(c, "name") and c.name]
+    assert "ck_messages_role" in constraints

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -1,9 +1,20 @@
 """Tests for Conversation and Message models."""
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
-from pam.common.models import Conversation, Message
+import pytest
+
+from pam.common.models import (
+    Conversation,
+    ConversationCreate,
+    ConversationDetail,
+    ConversationResponse,
+    ConvMessageResponse,
+    Message,
+    MessageCreate,
+)
 
 
 def test_conversation_model_has_required_fields():
@@ -32,15 +43,6 @@ def test_message_role_constraint():
     assert "ck_messages_role" in constraints
 
 
-from pam.common.models import (
-    ConversationCreate,
-    ConversationResponse,
-    ConversationDetail,
-    MessageCreate,
-    ConvMessageResponse,
-)
-
-
 def test_conversation_create_schema():
     """ConversationCreate accepts optional user_id, project_id, title."""
     c = ConversationCreate(title="Test Chat")
@@ -65,7 +67,7 @@ def test_message_create_schema():
 
 def test_conversation_response_schema():
     """ConversationResponse has all expected fields."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     cr = ConversationResponse(
         id=uuid.uuid4(),
         user_id=None,
@@ -80,7 +82,7 @@ def test_conversation_response_schema():
 
 def test_conversation_detail_includes_messages():
     """ConversationDetail extends ConversationResponse with messages list."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     msg = ConvMessageResponse(
         id=uuid.uuid4(),
         conversation_id=uuid.uuid4(),
@@ -100,11 +102,6 @@ def test_conversation_detail_includes_messages():
         messages=[msg],
     )
     assert len(detail.messages) == 1
-
-
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from pam.conversation.service import ConversationService
 
 
 @pytest.mark.asyncio
@@ -139,7 +136,7 @@ async def test_create_with_id(conversation_service, mock_session):
 async def test_get_conversation_found(conversation_service, mock_session):
     """get() returns ConversationDetail when conversation exists."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     mock_conv = MagicMock()
     mock_conv.id = conv_id
@@ -202,7 +199,7 @@ async def test_delete_conversation_not_found(conversation_service, mock_session)
 async def test_add_message(conversation_service, mock_session):
     """add_message() inserts a Message and updates last_active."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     mock_conv = MagicMock()
     mock_conv.id = conv_id
@@ -254,7 +251,7 @@ async def test_add_message_invalid_role(conversation_service):
 async def test_list_by_user(conversation_service, mock_session):
     """list_by_user() returns conversations ordered by last_active desc."""
     user_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     mock_conv = MagicMock()
     mock_conv.id = uuid.uuid4()
@@ -282,7 +279,7 @@ async def test_list_by_user(conversation_service, mock_session):
 async def test_get_recent_context(conversation_service, mock_session):
     """get_recent_context() returns formatted conversation text within token budget."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     msg1 = MagicMock()
     msg1.role = "user"

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -30,3 +30,73 @@ def test_message_role_constraint():
     """Message role column has a check constraint."""
     constraints = [c.name for c in Message.__table__.constraints if hasattr(c, "name") and c.name]
     assert "ck_messages_role" in constraints
+
+
+from pam.common.models import (
+    ConversationCreate,
+    ConversationResponse,
+    ConversationDetail,
+    MessageCreate,
+    ConvMessageResponse,
+)
+
+
+def test_conversation_create_schema():
+    """ConversationCreate accepts optional user_id, project_id, title."""
+    c = ConversationCreate(title="Test Chat")
+    assert c.title == "Test Chat"
+    assert c.user_id is None
+    assert c.project_id is None
+
+
+def test_conversation_create_minimal():
+    """ConversationCreate works with no arguments."""
+    c = ConversationCreate()
+    assert c.title is None
+
+
+def test_message_create_schema():
+    """MessageCreate requires role and content."""
+    m = MessageCreate(role="user", content="Hello")
+    assert m.role == "user"
+    assert m.content == "Hello"
+    assert m.metadata == {}
+
+
+def test_conversation_response_schema():
+    """ConversationResponse has all expected fields."""
+    now = datetime.now(tz=timezone.utc)
+    cr = ConversationResponse(
+        id=uuid.uuid4(),
+        user_id=None,
+        project_id=None,
+        title="Chat",
+        started_at=now,
+        last_active=now,
+        message_count=5,
+    )
+    assert cr.message_count == 5
+
+
+def test_conversation_detail_includes_messages():
+    """ConversationDetail extends ConversationResponse with messages list."""
+    now = datetime.now(tz=timezone.utc)
+    msg = ConvMessageResponse(
+        id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        role="user",
+        content="Hi",
+        metadata={},
+        created_at=now,
+    )
+    detail = ConversationDetail(
+        id=uuid.uuid4(),
+        user_id=None,
+        project_id=None,
+        title="Chat",
+        started_at=now,
+        last_active=now,
+        message_count=1,
+        messages=[msg],
+    )
+    assert len(detail.messages) == 1

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -196,3 +196,112 @@ async def test_delete_conversation_not_found(conversation_service, mock_session)
 
     result = await conversation_service.delete(uuid.uuid4())
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_add_message(conversation_service, mock_session):
+    """add_message() inserts a Message and updates last_active."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    mock_conv = MagicMock()
+    mock_conv.id = conv_id
+    mock_conv.last_active = now
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_conv
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.add_message(
+        conversation_id=conv_id,
+        role="user",
+        content="Hello, PAM!",
+    )
+
+    assert result.role == "user"
+    assert result.content == "Hello, PAM!"
+    assert result.conversation_id == conv_id
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_add_message_conversation_not_found(conversation_service, mock_session):
+    """add_message() raises ValueError when conversation doesn't exist."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    with pytest.raises(ValueError, match="not found"):
+        await conversation_service.add_message(
+            conversation_id=uuid.uuid4(),
+            role="user",
+            content="Hello",
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_message_invalid_role(conversation_service):
+    """add_message() raises ValueError for invalid role."""
+    with pytest.raises(ValueError, match="Invalid role"):
+        await conversation_service.add_message(
+            conversation_id=uuid.uuid4(),
+            role="admin",
+            content="Hello",
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_by_user(conversation_service, mock_session):
+    """list_by_user() returns conversations ordered by last_active desc."""
+    user_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    mock_conv = MagicMock()
+    mock_conv.id = uuid.uuid4()
+    mock_conv.user_id = user_id
+    mock_conv.project_id = None
+    mock_conv.title = "Chat 1"
+    mock_conv.started_at = now
+    mock_conv.last_active = now
+
+    # Mock the count subquery result
+    mock_row = MagicMock()
+    mock_row.Conversation = mock_conv
+    mock_row.message_count = 3
+
+    mock_result = MagicMock()
+    mock_result.all.return_value = [mock_row]
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.list_by_user(user_id=user_id)
+    assert len(result) == 1
+    assert result[0].message_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_recent_context(conversation_service, mock_session):
+    """get_recent_context() returns formatted conversation text within token budget."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    msg1 = MagicMock()
+    msg1.role = "user"
+    msg1.content = "What is our revenue target?"
+    msg1.created_at = now
+
+    msg2 = MagicMock()
+    msg2.role = "assistant"
+    msg2.content = "The Q1 revenue target is $10M."
+    msg2.created_at = now
+
+    mock_conv = MagicMock()
+    mock_conv.id = conv_id
+    mock_conv.messages = [msg1, msg2]
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_conv
+    mock_session.execute.return_value = mock_result
+
+    text = await conversation_service.get_recent_context(conv_id, max_tokens=2000)
+    assert "user:" in text
+    assert "assistant:" in text
+    assert "revenue target" in text

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -100,3 +100,99 @@ def test_conversation_detail_includes_messages():
         messages=[msg],
     )
     assert len(detail.messages) == 1
+
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from pam.conversation.service import ConversationService
+
+
+@pytest.mark.asyncio
+async def test_create_conversation(conversation_service, mock_session):
+    """create() inserts a Conversation row and returns ConversationResponse."""
+    user_id = uuid.uuid4()
+    result = await conversation_service.create(user_id=user_id, title="Test Chat")
+
+    mock_session.add.assert_called_once()
+    mock_session.flush.assert_awaited_once()
+    assert result.title == "Test Chat"
+    assert result.user_id == user_id
+    assert result.message_count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_with_id(conversation_service, mock_session):
+    """create_with_id() uses the supplied UUID instead of generating one."""
+    conv_id = uuid.uuid4()
+    result = await conversation_service.create_with_id(
+        conversation_id=conv_id, title="Chat with known ID"
+    )
+
+    mock_session.add.assert_called_once()
+    # The Conversation passed to session.add should have our ID
+    added_conv = mock_session.add.call_args[0][0]
+    assert added_conv.id == conv_id
+    assert result.title == "Chat with known ID"
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_found(conversation_service, mock_session):
+    """get() returns ConversationDetail when conversation exists."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    mock_conv = MagicMock()
+    mock_conv.id = conv_id
+    mock_conv.user_id = None
+    mock_conv.project_id = None
+    mock_conv.title = "Chat"
+    mock_conv.started_at = now
+    mock_conv.last_active = now
+    mock_conv.messages = []
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_conv
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.get(conv_id)
+    assert result is not None
+    assert result.id == conv_id
+    assert result.messages == []
+
+
+@pytest.mark.asyncio
+async def test_get_conversation_not_found(conversation_service, mock_session):
+    """get() returns None when conversation doesn't exist."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.get(uuid.uuid4())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation(conversation_service, mock_session):
+    """delete() removes conversation and returns True."""
+    conv_id = uuid.uuid4()
+
+    mock_conv = MagicMock()
+    mock_conv.id = conv_id
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_conv
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.delete(conv_id)
+    assert result is True
+    mock_session.delete.assert_awaited_once_with(mock_conv)
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_not_found(conversation_service, mock_session):
+    """delete() returns False when conversation doesn't exist."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    result = await conversation_service.delete(uuid.uuid4())
+    assert result is False

--- a/tests/conversation/test_summarizer.py
+++ b/tests/conversation/test_summarizer.py
@@ -32,15 +32,18 @@ def summarizer(mock_conversation_service, mock_memory_service):
 
 
 @pytest.mark.asyncio
-async def test_should_summarize_true(summarizer, mock_conversation_service):
+async def test_should_summarize_true(summarizer, mock_conversation_service, mock_memory_service):
     """should_summarize() returns the detail when message count exceeds threshold."""
     conv_id = uuid.uuid4()
     detail = MagicMock()
     detail.message_count = 10
     mock_conversation_service.get.return_value = detail
+    # Explicitly return no existing summaries so the dedup guard is tested
+    mock_memory_service.search.return_value = []
 
     result = await summarizer.should_summarize(conv_id)
     assert result is detail
+    mock_memory_service.search.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -50,6 +53,22 @@ async def test_should_summarize_false(summarizer, mock_conversation_service):
     detail = MagicMock()
     detail.message_count = 3
     mock_conversation_service.get.return_value = detail
+
+    result = await summarizer.should_summarize(conv_id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_should_summarize_already_summarized(summarizer, mock_conversation_service, mock_memory_service):
+    """should_summarize() returns None when a summary already exists for this conversation."""
+    conv_id = uuid.uuid4()
+    detail = MagicMock()
+    detail.message_count = 10
+    mock_conversation_service.get.return_value = detail
+
+    existing_summary = MagicMock()
+    existing_summary.memory.metadata = {"conversation_id": str(conv_id)}
+    mock_memory_service.search.return_value = [existing_summary]
 
     result = await summarizer.should_summarize(conv_id)
     assert result is None

--- a/tests/conversation/test_summarizer.py
+++ b/tests/conversation/test_summarizer.py
@@ -1,0 +1,132 @@
+"""Tests for ConversationSummarizer."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pam.conversation.summarizer import ConversationSummarizer
+
+
+@pytest.fixture
+def mock_memory_service():
+    svc = AsyncMock()
+    svc.store = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def mock_conversation_service():
+    svc = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def summarizer(mock_conversation_service, mock_memory_service):
+    return ConversationSummarizer(
+        conversation_service=mock_conversation_service,
+        memory_service=mock_memory_service,
+        anthropic_api_key="test-key",
+        model="claude-haiku-4-5-20251001",
+        summary_threshold=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_should_summarize_true(summarizer, mock_conversation_service):
+    """should_summarize() returns True when message count exceeds threshold."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+    detail = MagicMock()
+    detail.message_count = 10
+    mock_conversation_service.get.return_value = detail
+
+    result = await summarizer.should_summarize(conv_id)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_should_summarize_false(summarizer, mock_conversation_service):
+    """should_summarize() returns False when message count is below threshold."""
+    conv_id = uuid.uuid4()
+    detail = MagicMock()
+    detail.message_count = 3
+    mock_conversation_service.get.return_value = detail
+
+    result = await summarizer.should_summarize(conv_id)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_should_summarize_not_found(summarizer, mock_conversation_service):
+    """should_summarize() returns False when conversation not found."""
+    mock_conversation_service.get.return_value = None
+    result = await summarizer.should_summarize(uuid.uuid4())
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_summarize_creates_memory(summarizer, mock_conversation_service, mock_memory_service):
+    """summarize() generates summary and stores as conversation_summary memory."""
+    conv_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    msg1 = MagicMock()
+    msg1.role = "user"
+    msg1.content = "Tell me about our Q1 targets"
+    msg2 = MagicMock()
+    msg2.role = "assistant"
+    msg2.content = "The Q1 revenue target is $10M across all regions."
+
+    detail = MagicMock()
+    detail.messages = [msg1, msg2]
+    detail.user_id = user_id
+    detail.project_id = None
+    detail.id = conv_id
+    detail.message_count = 6
+    mock_conversation_service.get.return_value = detail
+
+    llm_response = MagicMock()
+    text_block = MagicMock()
+    text_block.text = "Discussion about Q1 revenue targets: $10M across all regions."
+    llm_response.content = [text_block]
+
+    with patch.object(summarizer, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(return_value=llm_response)
+
+        summary = await summarizer.summarize(conv_id)
+
+    assert "Q1" in summary
+    mock_memory_service.store.assert_awaited_once()
+    call_kwargs = mock_memory_service.store.call_args.kwargs
+    assert call_kwargs["memory_type"] == "conversation_summary"
+    assert call_kwargs["user_id"] == user_id
+
+
+@pytest.mark.asyncio
+async def test_summarize_not_found(summarizer, mock_conversation_service):
+    """summarize() returns empty string when conversation not found."""
+    mock_conversation_service.get.return_value = None
+    result = await summarizer.summarize(uuid.uuid4())
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_summarize_handles_llm_error(summarizer, mock_conversation_service, mock_memory_service):
+    """summarize() returns empty string on LLM failure."""
+    detail = MagicMock()
+    detail.messages = [MagicMock(role="user", content="Hello")]
+    detail.user_id = None
+    detail.project_id = None
+    detail.id = uuid.uuid4()
+    detail.message_count = 6
+    mock_conversation_service.get.return_value = detail
+
+    with patch.object(summarizer, "_client") as mock_client:
+        mock_client.messages.create = AsyncMock(side_effect=Exception("API error"))
+        result = await summarizer.summarize(detail.id)
+
+    assert result == ""
+    mock_memory_service.store.assert_not_awaited()

--- a/tests/conversation/test_summarizer.py
+++ b/tests/conversation/test_summarizer.py
@@ -37,13 +37,14 @@ async def test_should_summarize_true(summarizer, mock_conversation_service, mock
     conv_id = uuid.uuid4()
     detail = MagicMock()
     detail.message_count = 10
+    detail.user_id = uuid.uuid4()
     mock_conversation_service.get.return_value = detail
     # Explicitly return no existing summaries so the dedup guard is tested
-    mock_memory_service.search.return_value = []
+    mock_memory_service.find_by_metadata.return_value = []
 
     result = await summarizer.should_summarize(conv_id)
     assert result is detail
-    mock_memory_service.search.assert_awaited_once()
+    mock_memory_service.find_by_metadata.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -64,11 +65,12 @@ async def test_should_summarize_already_summarized(summarizer, mock_conversation
     conv_id = uuid.uuid4()
     detail = MagicMock()
     detail.message_count = 10
+    detail.user_id = uuid.uuid4()
     mock_conversation_service.get.return_value = detail
 
     existing_summary = MagicMock()
-    existing_summary.memory.metadata = {"conversation_id": str(conv_id)}
-    mock_memory_service.search.return_value = [existing_summary]
+    existing_summary.metadata = {"conversation_id": str(conv_id)}
+    mock_memory_service.find_by_metadata.return_value = [existing_summary]
 
     result = await summarizer.should_summarize(conv_id)
     assert result is None

--- a/tests/conversation/test_summarizer.py
+++ b/tests/conversation/test_summarizer.py
@@ -35,7 +35,7 @@ def summarizer(mock_conversation_service, mock_memory_service):
 
 @pytest.mark.asyncio
 async def test_should_summarize_true(summarizer, mock_conversation_service):
-    """should_summarize() returns True when message count exceeds threshold."""
+    """should_summarize() returns the detail when message count exceeds threshold."""
     conv_id = uuid.uuid4()
     now = datetime.now(tz=timezone.utc)
     detail = MagicMock()
@@ -43,27 +43,27 @@ async def test_should_summarize_true(summarizer, mock_conversation_service):
     mock_conversation_service.get.return_value = detail
 
     result = await summarizer.should_summarize(conv_id)
-    assert result is True
+    assert result is detail
 
 
 @pytest.mark.asyncio
 async def test_should_summarize_false(summarizer, mock_conversation_service):
-    """should_summarize() returns False when message count is below threshold."""
+    """should_summarize() returns None when message count is below threshold."""
     conv_id = uuid.uuid4()
     detail = MagicMock()
     detail.message_count = 3
     mock_conversation_service.get.return_value = detail
 
     result = await summarizer.should_summarize(conv_id)
-    assert result is False
+    assert result is None
 
 
 @pytest.mark.asyncio
 async def test_should_summarize_not_found(summarizer, mock_conversation_service):
-    """should_summarize() returns False when conversation not found."""
+    """should_summarize() returns None when conversation not found."""
     mock_conversation_service.get.return_value = None
     result = await summarizer.should_summarize(uuid.uuid4())
-    assert result is False
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/tests/conversation/test_summarizer.py
+++ b/tests/conversation/test_summarizer.py
@@ -1,7 +1,6 @@
 """Tests for ConversationSummarizer."""
 
 import uuid
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,8 +17,7 @@ def mock_memory_service():
 
 @pytest.fixture
 def mock_conversation_service():
-    svc = AsyncMock()
-    return svc
+    return AsyncMock()
 
 
 @pytest.fixture
@@ -37,7 +35,6 @@ def summarizer(mock_conversation_service, mock_memory_service):
 async def test_should_summarize_true(summarizer, mock_conversation_service):
     """should_summarize() returns the detail when message count exceeds threshold."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
     detail = MagicMock()
     detail.message_count = 10
     mock_conversation_service.get.return_value = detail
@@ -71,7 +68,6 @@ async def test_summarize_creates_memory(summarizer, mock_conversation_service, m
     """summarize() generates summary and stores as conversation_summary memory."""
     conv_id = uuid.uuid4()
     user_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
 
     msg1 = MagicMock()
     msg1.role = "user"

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -22,4 +22,5 @@ def mock_services() -> PamServices:
         duckdb_service=MagicMock(),
         cache_service=AsyncMock(),
         memory_service=AsyncMock(),
+        conversation_service=AsyncMock(),
     )

--- a/tests/mcp/test_conversation_tools.py
+++ b/tests/mcp/test_conversation_tools.py
@@ -1,0 +1,87 @@
+"""Tests for conversation MCP tools."""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pam.mcp import server as mcp_server
+from pam.mcp.services import PamServices
+
+
+@pytest.fixture(autouse=True)
+def _init_services(mock_services: PamServices):
+    mcp_server.initialize(mock_services)
+    yield
+    mcp_server._services = None
+
+
+@pytest.mark.asyncio
+async def test_pam_save_conversation(mock_services):
+    """pam_save_conversation stores messages in a conversation."""
+    conv_id = uuid.uuid4()
+    now = datetime.now(tz=timezone.utc)
+
+    mock_services.conversation_service.create.return_value = MagicMock(id=conv_id, title="Test Chat")
+    mock_services.conversation_service.add_message.return_value = MagicMock(
+        id=uuid.uuid4(),
+        conversation_id=conv_id,
+        role="user",
+        content="Hello",
+        created_at=now,
+    )
+
+    result = await mcp_server._pam_save_conversation(
+        messages=[
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ],
+        title="Test Chat",
+    )
+
+    parsed = json.loads(result)
+    assert "conversation_id" in parsed
+    assert parsed["messages_saved"] == 2
+    assert mock_services.conversation_service.add_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_pam_get_conversation_context(mock_services):
+    """pam_get_conversation_context returns recent conversation context."""
+    conv_id = uuid.uuid4()
+    mock_services.conversation_service.get_recent_context.return_value = (
+        "user: What is PAM?\nassistant: PAM is a knowledge base."
+    )
+
+    result = await mcp_server._pam_get_conversation_context(
+        conversation_id=str(conv_id),
+    )
+
+    assert "PAM" in result
+    mock_services.conversation_service.get_recent_context.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pam_save_conversation_service_unavailable(mock_services):
+    """pam_save_conversation returns error when service is None."""
+    mock_services.conversation_service = None
+
+    result = await mcp_server._pam_save_conversation(
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+    parsed = json.loads(result)
+    assert "error" in parsed
+
+
+@pytest.mark.asyncio
+async def test_pam_get_conversation_context_service_unavailable(mock_services):
+    """pam_get_conversation_context returns error when service is None."""
+    mock_services.conversation_service = None
+
+    result = await mcp_server._pam_get_conversation_context(
+        conversation_id=str(uuid.uuid4()),
+    )
+    parsed = json.loads(result)
+    assert "error" in parsed

--- a/tests/mcp/test_conversation_tools.py
+++ b/tests/mcp/test_conversation_tools.py
@@ -2,8 +2,8 @@
 
 import json
 import uuid
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -22,7 +22,7 @@ def _init_services(mock_services: PamServices):
 async def test_pam_save_conversation(mock_services):
     """pam_save_conversation stores messages in a conversation."""
     conv_id = uuid.uuid4()
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     mock_services.conversation_service.create.return_value = MagicMock(id=conv_id, title="Test Chat")
     mock_services.conversation_service.add_message.return_value = MagicMock(

--- a/tests/memory/conftest.py
+++ b/tests/memory/conftest.py
@@ -10,7 +10,7 @@ from pam.memory.service import MemoryService
 from pam.memory.store import MemoryStore
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_es_client() -> AsyncMock:
     """Create a mock Elasticsearch client."""
     client = AsyncMock()
@@ -22,7 +22,7 @@ def mock_es_client() -> AsyncMock:
     return client
 
 
-@pytest.fixture()
+@pytest.fixture
 def memory_store(mock_es_client: AsyncMock) -> MemoryStore:
     """Create a MemoryStore with mocked ES client."""
     return MemoryStore(
@@ -32,7 +32,7 @@ def memory_store(mock_es_client: AsyncMock) -> MemoryStore:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_embedder() -> AsyncMock:
     """Create a mock embedder."""
     embedder = AsyncMock()
@@ -40,7 +40,7 @@ def mock_embedder() -> AsyncMock:
     return embedder
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_store() -> AsyncMock:
     """Create a mock MemoryStore."""
     store = AsyncMock(spec=MemoryStore)
@@ -52,7 +52,7 @@ def mock_store() -> AsyncMock:
     return store
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_session_factory() -> MagicMock:
     """Create a mock async session factory."""
     factory = MagicMock()
@@ -62,7 +62,7 @@ def mock_session_factory() -> MagicMock:
     return factory
 
 
-@pytest.fixture()
+@pytest.fixture
 def memory_service(mock_session_factory, mock_store, mock_embedder) -> MemoryService:
     """Create a MemoryService with all dependencies mocked."""
     return MemoryService(

--- a/tests/memory/test_service.py
+++ b/tests/memory/test_service.py
@@ -1,13 +1,12 @@
 """Tests for Memory model and schemas."""
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pam.common.models import Memory
-from pam.memory.service import MemoryService
+from pam.common.models import Memory, MemoryCreate, MemoryResponse
 
 
 def test_memory_model_has_required_fields():
@@ -19,9 +18,6 @@ def test_memory_model_has_required_fields():
         "expires_at", "created_at", "updated_at",
     }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
-
-
-from pam.common.models import MemoryCreate, MemoryResponse, MemoryUpdate, MemorySearchQuery
 
 
 def test_memory_create_schema_defaults():
@@ -62,7 +58,7 @@ def test_memory_create_rejects_oversized_content():
 
 def test_memory_response_from_attributes():
     """MemoryResponse can be constructed from ORM-like attributes."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     mr = MemoryResponse(
         id=uuid.uuid4(),
         type="fact",
@@ -123,8 +119,8 @@ async def test_store_memory_with_duplicate_merges(memory_service, mock_store, mo
     mock_existing.expires_at = None
     mock_existing.user_id = None
     mock_existing.project_id = None
-    mock_existing.created_at = datetime.now(tz=timezone.utc)
-    mock_existing.updated_at = datetime.now(tz=timezone.utc)
+    mock_existing.created_at = datetime.now(tz=UTC)
+    mock_existing.updated_at = datetime.now(tz=UTC)
 
     mock_get_result = MagicMock()
     mock_get_result.scalars.return_value.first.return_value = mock_existing
@@ -169,8 +165,8 @@ async def test_merge_uses_max_importance(memory_service, mock_store, mock_embedd
     mock_existing.expires_at = None
     mock_existing.user_id = None
     mock_existing.project_id = None
-    mock_existing.created_at = datetime.now(tz=timezone.utc)
-    mock_existing.updated_at = datetime.now(tz=timezone.utc)
+    mock_existing.created_at = datetime.now(tz=UTC)
+    mock_existing.updated_at = datetime.now(tz=UTC)
 
     mock_get_result = MagicMock()
     mock_get_result.scalars.return_value.first.return_value = mock_existing
@@ -214,8 +210,8 @@ async def test_search_memories(memory_service, mock_store, mock_embedder):
     mock_memory.metadata_ = {}
     mock_memory.last_accessed_at = None
     mock_memory.expires_at = None
-    mock_memory.created_at = datetime.now(tz=timezone.utc)
-    mock_memory.updated_at = datetime.now(tz=timezone.utc)
+    mock_memory.created_at = datetime.now(tz=UTC)
+    mock_memory.updated_at = datetime.now(tz=UTC)
 
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = [mock_memory]
@@ -250,8 +246,8 @@ async def test_get_memory_by_id(memory_service):
     mock_memory.metadata_ = {}
     mock_memory.last_accessed_at = None
     mock_memory.expires_at = None
-    mock_memory.created_at = datetime.now(tz=timezone.utc)
-    mock_memory.updated_at = datetime.now(tz=timezone.utc)
+    mock_memory.created_at = datetime.now(tz=UTC)
+    mock_memory.updated_at = datetime.now(tz=UTC)
 
     mock_result = MagicMock()
     mock_result.scalars.return_value.first.return_value = mock_memory
@@ -334,8 +330,8 @@ async def test_update_memory(memory_service, mock_store, mock_embedder):
     mock_memory.metadata_ = {}
     mock_memory.last_accessed_at = None
     mock_memory.expires_at = None
-    mock_memory.created_at = datetime.now(tz=timezone.utc)
-    mock_memory.updated_at = datetime.now(tz=timezone.utc)
+    mock_memory.created_at = datetime.now(tz=UTC)
+    mock_memory.updated_at = datetime.now(tz=UTC)
 
     mock_result = MagicMock()
     mock_result.scalars.return_value.first.return_value = mock_memory
@@ -371,8 +367,8 @@ async def test_update_importance_only(memory_service, mock_store, mock_embedder)
     mock_memory.metadata_ = {}
     mock_memory.last_accessed_at = None
     mock_memory.expires_at = None
-    mock_memory.created_at = datetime.now(tz=timezone.utc)
-    mock_memory.updated_at = datetime.now(tz=timezone.utc)
+    mock_memory.created_at = datetime.now(tz=UTC)
+    mock_memory.updated_at = datetime.now(tz=UTC)
 
     mock_result = MagicMock()
     mock_result.scalars.return_value.first.return_value = mock_memory
@@ -403,9 +399,9 @@ async def test_update_clear_expires_at(memory_service, mock_store):
     mock_memory.source = None
     mock_memory.metadata_ = {}
     mock_memory.last_accessed_at = None
-    mock_memory.expires_at = datetime.now(tz=timezone.utc)
-    mock_memory.created_at = datetime.now(tz=timezone.utc)
-    mock_memory.updated_at = datetime.now(tz=timezone.utc)
+    mock_memory.expires_at = datetime.now(tz=UTC)
+    mock_memory.created_at = datetime.now(tz=UTC)
+    mock_memory.updated_at = datetime.now(tz=UTC)
 
     mock_result = MagicMock()
     mock_result.scalars.return_value.first.return_value = mock_memory

--- a/tests/memory/test_store.py
+++ b/tests/memory/test_store.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from pam.memory.store import MemoryStore, get_memory_index_mapping
+from pam.memory.store import get_memory_index_mapping
 
 
 def test_memory_index_mapping_structure():

--- a/tests/test_agent/test_context_assembly.py
+++ b/tests/test_agent/test_context_assembly.py
@@ -640,3 +640,73 @@ class TestAssembleContext:
         assert result_with_redistribution.chunk_tokens_used > 0
         assert result_with_redistribution.entity_tokens_used == 0
         assert result_with_redistribution.relationship_tokens_used == 0
+
+
+def test_assemble_context_with_memories():
+    """assemble_context() includes memory section when memories provided."""
+    memories = [
+        {"content": "User prefers Python for backend work", "type": "preference", "score": 0.95},
+        {"content": "Team uses PostgreSQL for analytics", "type": "fact", "score": 0.88},
+    ]
+    result = assemble_context(
+        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        memory_results=memories,
+    )
+    assert "User Memories" in result.text
+    assert "User prefers Python" in result.text
+    assert "PostgreSQL" in result.text
+    assert result.memory_tokens_used > 0
+
+
+def test_assemble_context_with_conversation():
+    """assemble_context() includes conversation section when provided."""
+    conversation_context = "user: What is our Q1 target?\nassistant: The Q1 target is $10M."
+    result = assemble_context(
+        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        conversation_context=conversation_context,
+    )
+    assert "Recent Conversation" in result.text
+    assert "Q1 target" in result.text
+    assert result.conversation_tokens_used > 0
+
+
+def test_assemble_context_with_all_sources():
+    """assemble_context() includes all sections when all sources provided."""
+    memories = [
+        {"content": "User prefers concise answers", "type": "preference", "score": 0.9},
+    ]
+    conversation_context = "user: Summarize the report.\nassistant: Here's the summary."
+    entity_results = [
+        {"name": "Revenue", "entity_type": "metric", "description": "Total revenue", "score": 0.8},
+    ]
+    result = assemble_context(
+        es_results=[], graph_text="", entity_vdb_results=entity_results, rel_vdb_results=[],
+        memory_results=memories, conversation_context=conversation_context,
+    )
+    assert "User Memories" in result.text
+    assert "Recent Conversation" in result.text
+    assert "Knowledge Graph Entities" in result.text
+
+
+def test_assemble_context_empty_memories_omitted():
+    """assemble_context() omits memory section when no memories provided."""
+    result = assemble_context(
+        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        memory_results=[], conversation_context="",
+    )
+    assert "User Memories" not in result.text
+    assert "Recent Conversation" not in result.text
+
+
+def test_assemble_context_memory_token_budget():
+    """assemble_context() respects memory token budget."""
+    memories = [
+        {"content": "fact " * 500, "type": "fact", "score": 0.9},
+        {"content": "another fact " * 500, "type": "fact", "score": 0.8},
+    ]
+    budget = ContextBudget(memory_tokens=200)
+    result = assemble_context(
+        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        memory_results=memories, budget=budget,
+    )
+    assert result.memory_tokens_used <= 250  # some overhead for headers

--- a/tests/test_agent/test_smart_search_context.py
+++ b/tests/test_agent/test_smart_search_context.py
@@ -304,7 +304,9 @@ class TestSmartSearchContextAssembly:
             "ANTHROPIC_API_KEY": "test",
             "CONTEXT_ENTITY_BUDGET": "2000",
             "CONTEXT_RELATIONSHIP_BUDGET": "3000",
-            "CONTEXT_MAX_TOKENS": "8000",
+            "CONTEXT_MAX_TOKENS": "10000",
+            "CONTEXT_MEMORY_BUDGET": "1000",
+            "CONVERSATION_CONTEXT_MAX_TOKENS": "1000",
         },
         clear=True,
     )
@@ -317,7 +319,7 @@ class TestSmartSearchContextAssembly:
             s = Settings(_env_file=None)
             assert s.context_entity_budget == 2000
             assert s.context_relationship_budget == 3000
-            assert s.context_max_tokens == 8000
+            assert s.context_max_tokens == 10000
 
             # Use patch to intercept assemble_context and verify budget
             with patch(
@@ -342,6 +344,6 @@ class TestSmartSearchContextAssembly:
                 assert budget is not None
                 assert budget.entity_tokens == 2000
                 assert budget.relationship_tokens == 3000
-                assert budget.max_total_tokens == 8000
+                assert budget.max_total_tokens == 10000
         finally:
             reset_settings()

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -122,6 +122,7 @@ class TestJwtSecretValidation:
 def test_conversation_settings_defaults():
     """Conversation settings have expected defaults."""
     s = Settings(
+        _env_file=None,
         anthropic_api_key="test-key",
         openai_api_key="test-key",
     )

--- a/tests/test_common/test_config.py
+++ b/tests/test_common/test_config.py
@@ -119,6 +119,20 @@ class TestJwtSecretValidation:
                 Settings(_env_file=None, auth_required=True, jwt_secret=secret, **_VALID_API_KEYS)
 
 
+def test_conversation_settings_defaults():
+    """Conversation settings have expected defaults."""
+    s = Settings(
+        anthropic_api_key="test-key",
+        openai_api_key="test-key",
+    )
+    assert s.conversation_extraction_enabled is True
+    assert s.conversation_extraction_model == "claude-haiku-4-5-20251001"
+    assert s.conversation_summary_threshold == 20
+    assert s.conversation_summary_token_limit == 8000
+    assert s.conversation_context_max_tokens == 2000
+    assert s.context_memory_budget == 2000
+
+
 class TestGetSettings:
     def test_get_settings_returns_settings_instance(self):
         """get_settings() should return a Settings instance."""


### PR DESCRIPTION
## Summary

- **Conversation persistence**: `ConversationService` with full CRUD, message storage, and token-budgeted recent context retrieval (`conversations` + `messages` tables via Alembic migration 009)
- **Automatic fact extraction**: `FactExtractionPipeline` uses Claude Haiku to extract facts/preferences from each chat exchange and stores them via `MemoryService` with dedup
- **Conversation summarization**: `ConversationSummarizer` compresses long conversations (threshold-configurable) into `conversation_summary` memories with token-limited input
- **Context assembly integration**: `assemble_context()` gains two new sections — User Memories and Recent Conversation — with independent token budgets
- **Agent wiring**: `RetrievalAgent._smart_search()` fetches user memories and conversation context per-request before assembling context
- **REST API**: 5 endpoints under `/api/conversations` (create, get, list, add message, delete) with ownership enforcement
- **MCP tools**: `pam_save_conversation` and `pam_get_conversation_context` for external agent access
- **Chat auto-persist**: Both `/api/chat` and `/api/chat/stream` inline-persist exchanges and trigger extraction + summarization
- **App startup wiring**: `ConversationService`, `FactExtractionPipeline`, and `ConversationSummarizer` initialized in lifespan with graceful fallback

## New files

```
src/pam/conversation/__init__.py
src/pam/conversation/service.py
src/pam/conversation/extraction.py
src/pam/conversation/summarizer.py
src/pam/api/routes/conversation.py
alembic/versions/009_add_conversations.py
tests/conversation/conftest.py
tests/conversation/test_service.py
tests/conversation/test_extraction.py
tests/conversation/test_summarizer.py
tests/conversation/test_routes.py
tests/mcp/test_conversation_tools.py
```

## Test plan

- [x] 928 unit tests pass (47 new, 881 pre-existing)
- [ ] Verify migration 009 applies cleanly on a fresh database
- [ ] Manual test: POST /api/chat persists messages and extracts facts
- [ ] Manual test: Conversation summarization triggers after threshold
- [ ] Manual test: MCP tools work via SSE transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)