### PR TITLE
fix(lint): break long line in _search_knowledge (E501)

### DIFF
--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -770,7 +770,11 @@ class RetrievalAgent:
             url_part = f" ({r.source_url})" if r.source_url else ""
             formatted_parts.append(f"[Result {i}] Source: {source_label}{url_part}\n{r.content}")
 
-        search_body = "\n\n---\n\n".join(formatted_parts) if formatted_parts else "No relevant results found for this query."
+        search_body = (
+            "\n\n---\n\n".join(formatted_parts)
+            if formatted_parts
+            else "No relevant results found for this query."
+        )
 
         # Prepend memory + conversation sections so the LLM sees per-user context
         # even when it chose search_knowledge over smart_search.


### PR DESCRIPTION
## Summary
- One-line follow-up to #46 — ruff E501 at src/pam/agent/agent.py:773 (125 > 120) introduced in 0d0b15a broke backend CI on main.
- Split the ternary search_body assignment across multiple lines.

## Test plan
- [x] ruff check src/ tests/ passes
- [x] tests/test_agent/ passes (272 tests)