### PR TITLE
chore(format): apply ruff format to unblock backend CI

### DIFF
--- a/src/pam/agent/agent.py
+++ b/src/pam/agent/agent.py
@@ -474,8 +474,7 @@ class RetrievalAgent:
                     top_k=5,
                 )
                 memory_results = [
-                    {"content": m.memory.content, "type": m.memory.type, "score": m.score}
-                    for m in raw_memories
+                    {"content": m.memory.content, "type": m.memory.type, "score": m.score} for m in raw_memories
                 ]
             except Exception:
                 logger.warning("user_context_memory_failed", exc_info=True)
@@ -771,9 +770,7 @@ class RetrievalAgent:
             formatted_parts.append(f"[Result {i}] Source: {source_label}{url_part}\n{r.content}")
 
         search_body = (
-            "\n\n---\n\n".join(formatted_parts)
-            if formatted_parts
-            else "No relevant results found for this query."
+            "\n\n---\n\n".join(formatted_parts) if formatted_parts else "No relevant results found for this query."
         )
 
         # Prepend memory + conversation sections so the LLM sees per-user context

--- a/src/pam/agent/context_assembly.py
+++ b/src/pam/agent/context_assembly.py
@@ -307,7 +307,10 @@ def assemble_context(
     memory_results = memory_results or []
     memories_sorted = sorted(memory_results, key=lambda x: x.get("score", 0), reverse=True)
     memories_truncated, memory_tokens_used, _ = truncate_list_by_token_budget(
-        memories_sorted, "content", budget.memory_tokens, budget.max_item_tokens,
+        memories_sorted,
+        "content",
+        budget.memory_tokens,
+        budget.max_item_tokens,
     )
 
     conversation_tokens_used = 0
@@ -396,8 +399,11 @@ def assemble_context(
     )
 
     total_tokens = (
-        entity_tokens_used + relationship_tokens_used + chunk_tokens_used
-        + memory_tokens_used + conversation_tokens_used
+        entity_tokens_used
+        + relationship_tokens_used
+        + chunk_tokens_used
+        + memory_tokens_used
+        + conversation_tokens_used
     )
 
     logger.debug(

--- a/src/pam/api/routes/chat.py
+++ b/src/pam/api/routes/chat.py
@@ -174,7 +174,10 @@ async def chat_debug(
 
     # Persist exchange inline (same as chat/chat_stream)
     await _persist_exchange(
-        request, conversation_id, body.message, result.answer,
+        request,
+        conversation_id,
+        body.message,
+        result.answer,
         user_id=_user.id if _user else None,
     )
 
@@ -229,7 +232,10 @@ async def chat(
 
     # Persist exchange inline
     await _persist_exchange(
-        request, conversation_id, body.message, result.answer,
+        request,
+        conversation_id,
+        body.message,
+        result.answer,
         user_id=_user.id if _user else None,
     )
 
@@ -290,7 +296,10 @@ async def chat_stream(
             # Persist after streaming completes (or on client disconnect)
             if full_response:
                 await _persist_exchange(
-                    request, conversation_id, body.message, full_response,
+                    request,
+                    conversation_id,
+                    body.message,
+                    full_response,
                     user_id=_user.id if _user else None,
                 )
 

--- a/src/pam/conversation/service.py
+++ b/src/pam/conversation/service.py
@@ -29,6 +29,7 @@ def _get_encoder() -> tiktoken.Encoding:
         _encoder = tiktoken.get_encoding("cl100k_base")
     return _encoder
 
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -60,9 +61,7 @@ def _conversation_to_response(conv: Conversation, message_count: int = 0) -> Con
     )
 
 
-def _conversation_to_detail(
-    conv: Conversation, message_limit: int | None = None
-) -> ConversationDetail:
+def _conversation_to_detail(conv: Conversation, message_limit: int | None = None) -> ConversationDetail:
     """Convert a Conversation ORM instance to ConversationDetail with messages.
 
     Parameters
@@ -258,10 +257,7 @@ class ConversationService:
 
             result = await session.execute(stmt)
             rows = result.all()
-            return [
-                _conversation_to_response(row.Conversation, message_count=row.message_count)
-                for row in rows
-            ]
+            return [_conversation_to_response(row.Conversation, message_count=row.message_count) for row in rows]
 
     async def get_recent_context(
         self,

--- a/src/pam/conversation/summarizer.py
+++ b/src/pam/conversation/summarizer.py
@@ -24,6 +24,7 @@ def _get_encoder() -> tiktoken.Encoding:
         _encoder = tiktoken.get_encoding("cl100k_base")
     return _encoder
 
+
 _SUMMARY_PROMPT = """\
 Summarize this conversation into a concise paragraph that captures the key topics discussed, \
 decisions made, facts learned, and any action items. Focus on information that would be \
@@ -56,7 +57,8 @@ class ConversationSummarizer:
         self._summary_token_limit = summary_token_limit
 
     async def should_summarize(
-        self, conversation_id: uuid_mod.UUID,
+        self,
+        conversation_id: uuid_mod.UUID,
     ) -> object | None:
         """Check if a conversation exceeds the summary threshold.
 

--- a/src/pam/ingestion/connectors/gws_docs.py
+++ b/src/pam/ingestion/connectors/gws_docs.py
@@ -30,11 +30,13 @@ class GwsDocsConnector(CliConnector):
 
         for folder_id in self.folder_ids:
             query = f'mimeType="{GOOGLE_DOC_MIME}" and "{folder_id}" in parents'
-            params = json.dumps({
-                "q": query,
-                "pageSize": 100,
-                "fields": "files(id,name,owners,webViewLink,modifiedTime),nextPageToken",
-            })
+            params = json.dumps(
+                {
+                    "q": query,
+                    "pageSize": 100,
+                    "fields": "files(id,name,owners,webViewLink,modifiedTime),nextPageToken",
+                }
+            )
             result = await self.run_cli(
                 [
                     "drive",
@@ -64,9 +66,7 @@ class GwsDocsConnector(CliConnector):
     async def fetch_document(self, source_id: str) -> RawDocument:
         # Fetch file metadata (including modifiedTime for bi-temporal timestamps)
         meta_params = json.dumps({"fileId": source_id, "fields": "name,owners,webViewLink,modifiedTime"})
-        meta = await self.run_cli(
-            ["drive", "files", "get", "--params", meta_params]
-        )
+        meta = await self.run_cli(["drive", "files", "get", "--params", meta_params])
         title = meta.get("name", source_id)
         owner = meta.get("owners", [{}])[0].get("emailAddress") if meta.get("owners") else None
         modified_at = datetime.fromisoformat(meta["modifiedTime"]) if meta.get("modifiedTime") else None

--- a/src/pam/ingestion/connectors/gws_sheets.py
+++ b/src/pam/ingestion/connectors/gws_sheets.py
@@ -29,11 +29,13 @@ class GwsSheetsConnector(CliConnector):
 
         for folder_id in self.folder_ids:
             query = f'mimeType="{SHEETS_MIME}" and "{folder_id}" in parents'
-            params = json.dumps({
-                "q": query,
-                "pageSize": 100,
-                "fields": "files(id,name,owners,webViewLink,modifiedTime),nextPageToken",
-            })
+            params = json.dumps(
+                {
+                    "q": query,
+                    "pageSize": 100,
+                    "fields": "files(id,name,owners,webViewLink,modifiedTime),nextPageToken",
+                }
+            )
             result = await self.run_cli(
                 [
                     "drive",

--- a/src/pam/mcp/server.py
+++ b/src/pam/mcp/server.py
@@ -452,10 +452,7 @@ async def _pam_entity_history(entity_name: str, since: str | None = None) -> str
     if since:
         since_normalized = since.replace("Z", "+00:00")
         history = [
-            h
-            for h in history
-            if h.get("created_at")
-            and h["created_at"].replace("Z", "+00:00") >= since_normalized
+            h for h in history if h.get("created_at") and h["created_at"].replace("Z", "+00:00") >= since_normalized
         ]
 
     return json.dumps(
@@ -743,9 +740,7 @@ async def _pam_forget(memory_id: str, user_id: str) -> str:
 
     if deleted:
         return json.dumps({"deleted": True, "memory_id": memory_id})
-    return json.dumps(
-        {"deleted": False, "memory_id": memory_id, "error": "Memory not found"}
-    )
+    return json.dumps({"deleted": False, "memory_id": memory_id, "error": "Memory not found"})
 
 
 def _register_conversation_tools(mcp: FastMCP) -> None:
@@ -764,8 +759,10 @@ def _register_conversation_tools(mcp: FastMCP) -> None:
         Returns the conversation_id and number of messages saved.
         """
         return await _pam_save_conversation(
-            messages=messages, title=title,
-            user_id=user_id, project_id=project_id,
+            messages=messages,
+            title=title,
+            user_id=user_id,
+            project_id=project_id,
         )
 
     @mcp.tool()
@@ -809,10 +806,12 @@ async def _pam_save_conversation(
         if "role" not in msg or "content" not in msg:
             return json.dumps({"error": f"Message at index {i} missing required 'role' or 'content' key"})
         if msg["role"] not in valid_roles:
-            return json.dumps({
-                "error": f"Message at index {i} has invalid role '{msg['role']}'. "
-                f"Must be one of: {sorted(valid_roles)}",
-            })
+            return json.dumps(
+                {
+                    "error": f"Message at index {i} has invalid role '{msg['role']}'. "
+                    f"Must be one of: {sorted(valid_roles)}",
+                }
+            )
 
     conv = await svc.create(user_id=uid, project_id=pid, title=title)
 
@@ -838,11 +837,13 @@ async def _pam_save_conversation(
             )
         return json.dumps({"error": f"Failed to save conversation: {exc}"})
 
-    return json.dumps({
-        "conversation_id": str(conv.id),
-        "messages_saved": len(messages),
-        "title": conv.title,
-    })
+    return json.dumps(
+        {
+            "conversation_id": str(conv.id),
+            "messages_saved": len(messages),
+            "title": conv.title,
+        }
+    )
 
 
 async def _pam_get_conversation_context(

--- a/src/pam/memory/service.py
+++ b/src/pam/memory/service.py
@@ -171,9 +171,7 @@ class MemoryService:
             from sqlalchemy import delete as sa_delete
 
             async with self._session_factory() as rollback_session:
-                await rollback_session.execute(
-                    sa_delete(Memory).where(Memory.id == memory_id)
-                )
+                await rollback_session.execute(sa_delete(Memory).where(Memory.id == memory_id))
                 await rollback_session.commit()
             logger.error("memory_es_index_failed", memory_id=str(memory_id), exc_info=True)
             raise
@@ -207,9 +205,7 @@ class MemoryService:
         merged_embedding = embeddings[0]
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id == existing_id)
-            )
+            result = await session.execute(select(Memory).where(Memory.id == existing_id))
             existing = result.scalars().first()
             if existing is None:
                 logger.warning("memory_dedup_race", existing_id=str(existing_id))
@@ -286,9 +282,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id.in_(memory_ids))
-            )
+            result = await session.execute(select(Memory).where(Memory.id.in_(memory_ids)))
             memories = result.scalars().all()
 
         # Build scored results, ordered by ES score
@@ -311,9 +305,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id == memory_id)
-            )
+            result = await session.execute(select(Memory).where(Memory.id == memory_id))
             memory = result.scalars().first()
             if memory is None:
                 return None
@@ -328,9 +320,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id == memory_id)
-            )
+            result = await session.execute(select(Memory).where(Memory.id == memory_id))
             memory = result.scalars().first()
             if memory is None:
                 return None
@@ -376,11 +366,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            stmt = (
-                select(Memory)
-                .where(Memory.user_id == user_id)
-                .order_by(Memory.updated_at.desc())
-            )
+            stmt = select(Memory).where(Memory.user_id == user_id).order_by(Memory.updated_at.desc())
             if project_id:
                 stmt = stmt.where(Memory.project_id == project_id)
             if type_filter:
@@ -407,9 +393,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id == memory_id)
-            )
+            result = await session.execute(select(Memory).where(Memory.id == memory_id))
             memory = result.scalars().first()
             if memory is None:
                 return None
@@ -466,9 +450,7 @@ class MemoryService:
         except Exception:
             # Compensate: restore old PG values to keep PG↔ES consistent
             async with self._session_factory() as rollback_session:
-                res = await rollback_session.execute(
-                    select(Memory).where(Memory.id == memory_id)
-                )
+                res = await rollback_session.execute(select(Memory).where(Memory.id == memory_id))
                 mem = res.scalars().first()
                 if mem is not None:
                     mem.content = old_content
@@ -488,9 +470,7 @@ class MemoryService:
         from sqlalchemy import select
 
         async with self._session_factory() as session:
-            result = await session.execute(
-                select(Memory).where(Memory.id == memory_id)
-            )
+            result = await session.execute(select(Memory).where(Memory.id == memory_id))
             memory = result.scalars().first()
             if memory is None:
                 return False
@@ -520,10 +500,7 @@ class MemoryService:
                 messages=[
                     {
                         "role": "user",
-                        "content": (
-                            f"Existing memory: {old_content}\n\n"
-                            f"New memory: {new_content}"
-                        ),
+                        "content": (f"Existing memory: {old_content}\n\nNew memory: {new_content}"),
                     }
                 ],
             )

--- a/tests/conversation/test_extraction.py
+++ b/tests/conversation/test_extraction.py
@@ -107,10 +107,10 @@ async def test_extract_multiple_facts(extraction_pipeline, mock_memory_service):
     llm_response = MagicMock()
     text_block = MagicMock()
     text_block.text = (
-        '['
+        "["
         '{"type": "fact", "content": "Team uses PostgreSQL for analytics"},'
         '{"type": "preference", "content": "User prefers concise answers"}'
-        ']'
+        "]"
     )
     llm_response.content = [text_block]
 

--- a/tests/conversation/test_routes.py
+++ b/tests/conversation/test_routes.py
@@ -96,8 +96,12 @@ async def test_add_message(client, mock_conv_service):
     now = datetime.now(tz=UTC)
     # Need to mock get() for ownership check
     mock_conv_service.get.return_value = ConversationDetail(
-        id=conv_id, title="Chat", started_at=now, last_active=now,
-        message_count=1, messages=[],
+        id=conv_id,
+        title="Chat",
+        started_at=now,
+        last_active=now,
+        message_count=1,
+        messages=[],
     )
     mock_conv_service.add_message.return_value = ConvMessageResponse(
         id=uuid.uuid4(),
@@ -146,8 +150,12 @@ async def test_delete_conversation(client, mock_conv_service):
     now = datetime.now(tz=UTC)
     # Mock get for ownership check
     mock_conv_service.get.return_value = ConversationDetail(
-        id=conv_id, title="Chat", started_at=now, last_active=now,
-        message_count=0, messages=[],
+        id=conv_id,
+        title="Chat",
+        started_at=now,
+        last_active=now,
+        message_count=0,
+        messages=[],
     )
     mock_conv_service.delete.return_value = True
 

--- a/tests/conversation/test_service.py
+++ b/tests/conversation/test_service.py
@@ -21,8 +21,12 @@ def test_conversation_model_has_required_fields():
     """Conversation ORM model has all expected columns."""
     columns = {c.name for c in Conversation.__table__.columns}
     expected = {
-        "id", "user_id", "project_id", "title",
-        "started_at", "last_active",
+        "id",
+        "user_id",
+        "project_id",
+        "title",
+        "started_at",
+        "last_active",
     }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
 
@@ -31,8 +35,12 @@ def test_message_model_has_required_fields():
     """Message ORM model has all expected columns."""
     columns = {c.name for c in Message.__table__.columns}
     expected = {
-        "id", "conversation_id", "role", "content",
-        "metadata", "created_at",
+        "id",
+        "conversation_id",
+        "role",
+        "content",
+        "metadata",
+        "created_at",
     }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
 
@@ -121,9 +129,7 @@ async def test_create_conversation(conversation_service, mock_session):
 async def test_create_with_id(conversation_service, mock_session):
     """create_with_id() uses the supplied UUID instead of generating one."""
     conv_id = uuid.uuid4()
-    result = await conversation_service.create_with_id(
-        conversation_id=conv_id, title="Chat with known ID"
-    )
+    result = await conversation_service.create_with_id(conversation_id=conv_id, title="Chat with known ID")
 
     mock_session.add.assert_called_once()
     # The Conversation passed to session.add should have our ID

--- a/tests/mcp/test_memory_tools.py
+++ b/tests/mcp/test_memory_tools.py
@@ -107,8 +107,12 @@ async def test_pam_forget_deletes_memory(mock_services: PamServices):
     memory_id = uuid.uuid4()
     mock_services.memory_service.get_for_ownership_check = AsyncMock(
         return_value=MemoryResponse(
-            id=memory_id, type="fact", content="x", importance=0.5,
-            access_count=0, user_id=user_id,
+            id=memory_id,
+            type="fact",
+            content="x",
+            importance=0.5,
+            access_count=0,
+            user_id=user_id,
             created_at=datetime.now(tz=UTC),
             updated_at=datetime.now(tz=UTC),
         )
@@ -148,8 +152,12 @@ async def test_pam_forget_rejects_wrong_owner(mock_services: PamServices):
     memory_id = uuid.uuid4()
     mock_services.memory_service.get_for_ownership_check = AsyncMock(
         return_value=MemoryResponse(
-            id=memory_id, type="fact", content="x", importance=0.5,
-            access_count=0, user_id=owner_id,
+            id=memory_id,
+            type="fact",
+            content="x",
+            importance=0.5,
+            access_count=0,
+            user_id=owner_id,
             created_at=datetime.now(tz=UTC),
             updated_at=datetime.now(tz=UTC),
         )

--- a/tests/memory/test_service.py
+++ b/tests/memory/test_service.py
@@ -13,9 +13,19 @@ def test_memory_model_has_required_fields():
     """Memory ORM model has all expected columns."""
     columns = {c.name for c in Memory.__table__.columns}
     expected = {
-        "id", "user_id", "project_id", "type", "content", "source",
-        "metadata", "importance", "access_count", "last_accessed_at",
-        "expires_at", "created_at", "updated_at",
+        "id",
+        "user_id",
+        "project_id",
+        "type",
+        "content",
+        "source",
+        "metadata",
+        "importance",
+        "access_count",
+        "last_accessed_at",
+        "expires_at",
+        "created_at",
+        "updated_at",
     }
     assert expected.issubset(columns), f"Missing columns: {expected - columns}"
 
@@ -435,9 +445,7 @@ async def test_store_rejects_oversized_content(memory_service):
 async def test_merge_contents_fallback(memory_service):
     """_merge_contents falls back to new content when LLM call fails."""
     with patch("anthropic.AsyncAnthropic") as mock_cls:
-        mock_cls.return_value.messages.create = AsyncMock(
-            side_effect=RuntimeError("API unavailable")
-        )
+        mock_cls.return_value.messages.create = AsyncMock(side_effect=RuntimeError("API unavailable"))
 
         result = await memory_service._merge_contents("old fact", "new fact")
         assert result == "new fact"

--- a/tests/test_agent/test_context_assembly.py
+++ b/tests/test_agent/test_context_assembly.py
@@ -649,7 +649,10 @@ def test_assemble_context_with_memories():
         {"content": "Team uses PostgreSQL for analytics", "type": "fact", "score": 0.88},
     ]
     result = assemble_context(
-        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        es_results=[],
+        graph_text="",
+        entity_vdb_results=[],
+        rel_vdb_results=[],
         memory_results=memories,
     )
     assert "User Memories" in result.text
@@ -662,7 +665,10 @@ def test_assemble_context_with_conversation():
     """assemble_context() includes conversation section when provided."""
     conversation_context = "user: What is our Q1 target?\nassistant: The Q1 target is $10M."
     result = assemble_context(
-        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
+        es_results=[],
+        graph_text="",
+        entity_vdb_results=[],
+        rel_vdb_results=[],
         conversation_context=conversation_context,
     )
     assert "Recent Conversation" in result.text
@@ -680,8 +686,12 @@ def test_assemble_context_with_all_sources():
         {"name": "Revenue", "entity_type": "metric", "description": "Total revenue", "score": 0.8},
     ]
     result = assemble_context(
-        es_results=[], graph_text="", entity_vdb_results=entity_results, rel_vdb_results=[],
-        memory_results=memories, conversation_context=conversation_context,
+        es_results=[],
+        graph_text="",
+        entity_vdb_results=entity_results,
+        rel_vdb_results=[],
+        memory_results=memories,
+        conversation_context=conversation_context,
     )
     assert "User Memories" in result.text
     assert "Recent Conversation" in result.text
@@ -691,8 +701,12 @@ def test_assemble_context_with_all_sources():
 def test_assemble_context_empty_memories_omitted():
     """assemble_context() omits memory section when no memories provided."""
     result = assemble_context(
-        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
-        memory_results=[], conversation_context="",
+        es_results=[],
+        graph_text="",
+        entity_vdb_results=[],
+        rel_vdb_results=[],
+        memory_results=[],
+        conversation_context="",
     )
     assert "User Memories" not in result.text
     assert "Recent Conversation" not in result.text
@@ -706,7 +720,11 @@ def test_assemble_context_memory_token_budget():
     ]
     budget = ContextBudget(memory_tokens=200)
     result = assemble_context(
-        es_results=[], graph_text="", entity_vdb_results=[], rel_vdb_results=[],
-        memory_results=memories, budget=budget,
+        es_results=[],
+        graph_text="",
+        entity_vdb_results=[],
+        rel_vdb_results=[],
+        memory_results=memories,
+        budget=budget,
     )
     assert result.memory_tokens_used <= 250  # some overhead for headers


### PR DESCRIPTION
## Summary
- CI 'Format check' step (`ruff format --check`) has been failing on main since PR #46 was merged. The step has existed in `.github/workflows/ci.yml` for many commits, but 15 files had drifted from ruff's canonical formatting.
- Running `ruff format` locally produces only cosmetic changes (line wrapping, trailing commas, blank lines) — no semantic diff.

## Test plan
- [x] `ruff format --check src/ tests/` passes
- [x] `ruff check src/ tests/` passes
- [x] Full unit suite: 932 tests pass